### PR TITLE
docs: document beta API import using ?api-version=beta query parameter

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -137,4 +137,7 @@ Optional:
  # MSGraph resource can be imported using the resource id, e.g.
  terraform import msgraph_resource.servicePrincipal /servicePrincipals/00000000-0000-0000-0000-000000000000
  terraform import msgraph_resource.member /groups/group-id/members/$ref/00000000-0000-0000-0000-000000000000
+ 
+ # For resources that use the beta API, append ?api-version=beta to the import ID:
+ terraform import msgraph_resource.settings '/settings/00000000-0000-0000-0000-000000000000?api-version=beta'
  ```

--- a/examples/resources/msgraph_resource/import.sh
+++ b/examples/resources/msgraph_resource/import.sh
@@ -1,3 +1,6 @@
 # MSGraph resource can be imported using the resource id, e.g.
 terraform import msgraph_resource.servicePrincipal /servicePrincipals/00000000-0000-0000-0000-000000000000
 terraform import msgraph_resource.member /groups/group-id/members/$ref/00000000-0000-0000-0000-000000000000
+
+# For resources that use the beta API, append ?api-version=beta to the import ID:
+terraform import msgraph_resource.settings '/settings/00000000-0000-0000-0000-000000000000?api-version=beta'


### PR DESCRIPTION
## Summary

Fixes #92 — documents how to import resources that use the beta API endpoint.

The `ImportState` method already supports a `?api-version=beta` query parameter in the import ID, but this was not documented anywhere. Users importing beta-only resources (e.g. `settings`) would get a confusing `400 Bad Request` error because the provider defaulted to `v1.0`.

## Changes

- **docs/resources/resource.md** — Added beta import example to the Import section
- **examples/resources/msgraph_resource/import.sh** — Added beta import example

## Usage

```shell
# For beta API resources, append ?api-version=beta:
terraform import msgraph_resource.settings '/settings/00000000-0000-0000-0000-000000000000?api-version=beta'
```