### PR TITLE
feat: add collection_type parameter to `msgraph_resource_collection`

### DIFF
--- a/docs/resources/resource_collection.md
+++ b/docs/resources/resource_collection.md
@@ -86,6 +86,7 @@ Manage the full contents of a child reference collection (such as group members 
 ### Optional
 
 - `api_version` (String) The API version of the data source. The allowed values are `v1.0` and `beta`. Defaults to `v1.0`.
+- `collection_type` (String) The OData collection type path used when constructing `@odata.id` references. Defaults to `directoryObjects`. Override this for APIs that require a specific collection type, e.g. `identityGovernance/entitlementManagement/accessPackages`.
 - `read_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the read (list) requests.
 - `reference_ids` (List of String) List of object IDs that MUST exist in this `$ref` collection. Missing IDs are added; extra remote items are removed. Order is ignored. Each value should be the GUID (or string identifier) of an existing directory object (user, group, service principal, etc.).
 - `response_export_values` (Map of String) A map where the key is the name for the result and the value is a JMESPath query string to filter the response. Here's an example. If it sets to `{"all" = "@", "app_id" = "appId"}`, it will set the following HCL object to the computed property output.

--- a/internal/services/msgraph_resource_collection.go
+++ b/internal/services/msgraph_resource_collection.go
@@ -45,6 +45,7 @@ type MSGraphResourceCollectionModel struct {
 	Id                   types.String      `tfsdk:"id"`
 	ApiVersion           types.String      `tfsdk:"api_version"`
 	Url                  types.String      `tfsdk:"url"`
+	CollectionType       types.String      `tfsdk:"collection_type"`
 	ReferenceIds         types.List        `tfsdk:"reference_ids"`
 	ReadQueryParameters  types.Map         `tfsdk:"read_query_parameters"`
 	Retry                retry.Value       `tfsdk:"retry"`
@@ -86,6 +87,13 @@ func (r *MSGraphResourceCollection) Schema(ctx context.Context, req resource.Sch
 				Computed:            true,
 				Validators:          []validator.String{stringvalidator.OneOf("v1.0", "beta")},
 				Default:             stringdefault.StaticString("v1.0"),
+			},
+
+			"collection_type": schema.StringAttribute{
+				MarkdownDescription: "The OData collection type path used when constructing `@odata.id` references. Defaults to `directoryObjects`. Override this for APIs that require a specific collection type, e.g. `identityGovernance/entitlementManagement/accessPackages`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("directoryObjects"),
 			},
 
 			"reference_ids": schema.ListAttribute{
@@ -299,7 +307,7 @@ func (r *MSGraphResourceCollection) applyCollection(ctx context.Context, model *
 	errs := make([]error, 0)
 	for _, item := range toAdd {
 		body := map[string]string{}
-		body["@odata.id"] = fmt.Sprintf("%s/%s/directoryObjects/%s", r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), item)
+		body["@odata.id"] = fmt.Sprintf("%s/%s/%s/%s", r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), model.CollectionType.ValueString(), item)
 		_, err := r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), body, clients.RequestOptions{RetryOptions: clients.NewRetryOptions(model.Retry)})
 		if err != nil {
 			errs = append(errs, err)
@@ -366,6 +374,7 @@ func (r *MSGraphResourceCollection) ImportState(ctx context.Context, req resourc
 		Id:                  types.StringValue(baseCollectionUrl(urlValue)),
 		Url:                 types.StringValue(urlValue),
 		ApiVersion:          types.StringValue(apiVersion),
+		CollectionType:      types.StringValue("directoryObjects"),
 		ReferenceIds:        types.ListNull(types.StringType),
 		ReadQueryParameters: types.MapNull(types.ListType{ElemType: types.StringType}),
 		Retry:               retry.NewValueNull(),

--- a/internal/services/msgraph_resource_collection.go
+++ b/internal/services/msgraph_resource_collection.go
@@ -46,6 +46,7 @@ type MSGraphResourceCollectionModel struct {
 	Id                   types.String      `tfsdk:"id"`
 	ApiVersion           types.String      `tfsdk:"api_version"`
 	Url                  types.String      `tfsdk:"url"`
+	CollectionType       types.String      `tfsdk:"collection_type"`
 	ReferenceIds         types.List        `tfsdk:"reference_ids"`
 	SkipDestroy          types.Bool        `tfsdk:"skip_destroy"`
 	ReadQueryParameters  types.Map         `tfsdk:"read_query_parameters"`
@@ -88,6 +89,13 @@ func (r *MSGraphResourceCollection) Schema(ctx context.Context, req resource.Sch
 				Computed:            true,
 				Validators:          []validator.String{stringvalidator.OneOf("v1.0", "beta")},
 				Default:             stringdefault.StaticString("v1.0"),
+			},
+
+			"collection_type": schema.StringAttribute{
+				MarkdownDescription: "The OData collection type path used when constructing `@odata.id` references. Defaults to `directoryObjects`. Override this for APIs that require a specific collection type, e.g. `identityGovernance/entitlementManagement/accessPackages`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("directoryObjects"),
 			},
 
 			"reference_ids": schema.ListAttribute{
@@ -318,7 +326,7 @@ func (r *MSGraphResourceCollection) applyCollection(ctx context.Context, model *
 	errs := make([]error, 0)
 	for _, item := range toAdd {
 		body := map[string]string{}
-		body["@odata.id"] = fmt.Sprintf("%s/%s/directoryObjects/%s", r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), item)
+		body["@odata.id"] = fmt.Sprintf("%s/%s/%s/%s", r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), model.CollectionType.ValueString(), item)
 		_, _, err := r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), body, clients.RequestOptions{RetryOptions: clients.NewRetryOptions(model.Retry)})
 		if err != nil {
 			errs = append(errs, err)
@@ -416,6 +424,7 @@ func (r *MSGraphResourceCollection) ImportState(ctx context.Context, req resourc
 		Id:                  types.StringValue(baseCollectionUrl(urlValue)),
 		Url:                 types.StringValue(urlValue),
 		ApiVersion:          types.StringValue(apiVersion),
+		CollectionType:      types.StringValue("directoryObjects"),
 		ReferenceIds:        types.ListNull(types.StringType),
 		SkipDestroy:         types.BoolValue(false),
 		ReadQueryParameters: types.MapNull(types.ListType{ElemType: types.StringType}),


### PR DESCRIPTION
This PR adds support for an optional parameter `collection_type` on the `msgraph_resource_collection` resource.

It therefore allows managing resource collections where the actual object type must be provided instead of a generic `directoryObjects`.

Closes #104