### PR TITLE
fix: set MaxRetryDelay to honour Graph API Retry-After up to 315s

### DIFF
--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -107,8 +107,10 @@ func NewRetryOptionsForReadAfterCreate() *policy.RetryOptions {
 	statusCodes = append(statusCodes, DefaultRetryableReadAfterCreateStatusCodes...)
 	return &policy.RetryOptions{
 		// Set a very high max retries to make sure context deadline is respected.
-		MaxRetries:  math.MaxInt16,
-		StatusCodes: statusCodes,
+		MaxRetries: math.MaxInt16,
+		// Graph API Retry-After can reach 315s on Identity Governance endpoints, cap must exceed this.
+		MaxRetryDelay: 600 * time.Second,
+		StatusCodes:   statusCodes,
 		ShouldRetry: func(resp *http.Response, err error) bool {
 			// We need to test for status codes here too. This covers the case that these options are combined with
 			// retry options from NewRetryOptions, because the ShouldRetry function takes precedence over StatusCodes.
@@ -135,8 +137,10 @@ func NewRetryOptions(rtry retry.Value) *policy.RetryOptions {
 	log.Printf("[DEBUG] Using custom retry configuration")
 	return &policy.RetryOptions{
 		// Set a very high max retries to make sure context deadline is respected.
-		MaxRetries:  math.MaxInt16,
-		StatusCodes: DefaultRetryableStatusCodes,
+		MaxRetries: math.MaxInt16,
+		// Graph API Retry-After can reach 315s on Identity Governance endpoints, cap must exceed this.
+		MaxRetryDelay: 600 * time.Second,
+		StatusCodes:   DefaultRetryableStatusCodes,
 		ShouldRetry: func(resp *http.Response, err error) bool {
 			if resp == nil {
 				return err != nil


### PR DESCRIPTION
## Summary

Fixes #118.

The azure-sdk retry policy correctly reads the `Retry-After` header but caps the wait at `MaxRetryDelay`, which defaults to 60 s. The Graph API Identity Governance endpoint returns `Retry-After` values up to 315 s, causing the SDK to retry too early, re-hit 429, and exhaust retries before the throttle window clears.

Setting `MaxRetryDelay: 600 * time.Second` in both `NewRetryOptionsForReadAfterCreate` and `NewRetryOptions` ensures the full `Retry-After` duration is respected.

#133 ("apply retry policy by default") makes retry fire on every request, including the read-after-create/existence-check path. but it doesn't set `MaxRetryDelay`, so those retries are still capped at 60s. this pr is complementary: #133 = retry at all, this pr = retry waits the full `Retry-After` window. rebased on top of #133 so it applies cleanly.

## Changes

- `internal/clients/options.go`: added `MaxRetryDelay: 600 * time.Second` to both `NewRetryOptionsForReadAfterCreate` and `NewRetryOptions`.

## Note to maintainers

I apologies the original issue title ("Retry-After not honoured") was misleading. The real problem is the missing `MaxRetryDelay` cap. I've updated the issue body with the corrected root cause.

I'm relatively new to contributing to this provider and happy to revise the approach if the 600 s value or placement isn't right. Please let me know if you'd prefer a different cap, a configurable option, or if this belongs somewhere else in the retry pipeline. Thank you for reviewing