### PR TITLE
fix: fallback to locaton when top level id is not present

### DIFF
--- a/.azdo/acctest-pipeline.yml
+++ b/.azdo/acctest-pipeline.yml
@@ -6,8 +6,5 @@ trigger:
 
 pr: none
 
-variables:
-  TESTARGS: "-run TestAcc"
-
 extends:
   template: ci.yml

--- a/.azdo/acctest-pipeline.yml
+++ b/.azdo/acctest-pipeline.yml
@@ -6,5 +6,8 @@ trigger:
 
 pr: none
 
+variables:
+  TESTARGS: "-run TestAcc"
+
 extends:
   template: ci.yml

--- a/internal/clients/msgraph_client.go
+++ b/internal/clients/msgraph_client.go
@@ -230,17 +230,13 @@ func (client *MSGraphClient) Create(ctx context.Context, url string, apiVersion 
 		return nil, "", runtime.NewResponseError(resp)
 	}
 
-	// The Location header is only treated as the created resource's URL on a
-	// synchronous 201 Created response. On 202 Accepted, Microsoft Graph uses
-	// Location for a long-running-operation *monitor* URL whose final segment is
-	// an async job id, not the resource key, so it must not be used to derive the
-	// resource ID. See https://learn.microsoft.com/graph/long-running-actions-overview.
+	// Only use Location on a synchronous 201 Created. On 202 Accepted it points to
+	// a long-running-operation monitor URL, not the created resource.
+	// TODO: Handle long-running (202 Accepted) operations if needed.
 	location := ""
 	if resp.StatusCode == http.StatusCreated {
 		location = resp.Header.Get("Location")
 	}
-
-	// TODO: Handle long-running (202 Accepted) operations if needed.
 
 	var responseBody interface{}
 	if err := runtime.UnmarshalAsJSON(resp, &responseBody); err != nil {

--- a/internal/clients/msgraph_client.go
+++ b/internal/clients/msgraph_client.go
@@ -202,13 +202,13 @@ func (client *MSGraphClient) List(ctx context.Context, url string, apiVersion st
 	return out, nil
 }
 
-func (client *MSGraphClient) Create(ctx context.Context, url string, apiVersion string, body interface{}, options RequestOptions) (interface{}, error) {
+func (client *MSGraphClient) Create(ctx context.Context, url string, apiVersion string, body interface{}, options RequestOptions) (interface{}, string, error) {
 	if options.RetryOptions != nil {
 		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
 	}
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, apiVersion, url))
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	reqQP := req.Raw().URL.Query()
 	for key, value := range options.QueryParameters {
@@ -220,23 +220,33 @@ func (client *MSGraphClient) Create(ctx context.Context, url string, apiVersion 
 		req.Raw().Header.Set(key, value)
 	}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	resp, err := client.pl.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
-		return nil, runtime.NewResponseError(resp)
+		return nil, "", runtime.NewResponseError(resp)
 	}
 
-	// TODO: Handle long-running operations if needed
+	// The Location header is only treated as the created resource's URL on a
+	// synchronous 201 Created response. On 202 Accepted, Microsoft Graph uses
+	// Location for a long-running-operation *monitor* URL whose final segment is
+	// an async job id, not the resource key, so it must not be used to derive the
+	// resource ID. See https://learn.microsoft.com/graph/long-running-actions-overview.
+	location := ""
+	if resp.StatusCode == http.StatusCreated {
+		location = resp.Header.Get("Location")
+	}
+
+	// TODO: Handle long-running (202 Accepted) operations if needed.
 
 	var responseBody interface{}
 	if err := runtime.UnmarshalAsJSON(resp, &responseBody); err != nil {
-		return nil, err
+		return nil, location, err
 	}
-	return responseBody, nil
+	return responseBody, location, nil
 }
 
 func (client *MSGraphClient) Update(ctx context.Context, url string, apiVersion string, body interface{}, options RequestOptions) (interface{}, error) {

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -694,12 +695,9 @@ func buildOutputFromBody(body interface{}, paths map[string]string) attr.Value {
 	return out
 }
 
-// resolveResourceID returns the resource ID for a created resource: the response
-// body's top-level `id` when present, otherwise the last path segment of the
-// `Location` header (set by the client only for a synchronous 201 Created, so an
-// async 202 monitor URL is never used). Covers APIs keyed by a non-`id` field.
-// The result is verified
-// by the read of {url}/{id} that follows, so a wrong value fails loudly.
+// resolveResourceID returns the created resource ID: the response body's top-level
+// `id` when present, otherwise the last path segment of the `Location` header (for
+// APIs keyed by a non-`id` field).
 func resolveResourceID(responseBody interface{}, location string) (string, error) {
 	if responseMap, ok := responseBody.(map[string]interface{}); ok {
 		if id, ok := responseMap["id"].(string); ok && id != "" {
@@ -715,7 +713,7 @@ func resolveResourceID(responseBody interface{}, location string) (string, error
 		}
 	}
 
-	return "", fmt.Errorf("unable to determine the resource ID: the create response contained no top-level `id` field and no usable `Location` header")
+	return "", errors.New("unable to determine the resource ID: the create response contained no top-level `id` field and no usable `Location` header")
 }
 
 func (r *MSGraphResource) MoveState(ctx context.Context) []resource.StateMover {

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -242,7 +242,7 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 		QueryParameters: clients.NewQueryParameters(AsMapOfLists(model.CreateQueryParameters)),
 		RetryOptions:    clients.NewRetryOptions(model.Retry),
 	}
-	responseBody, err := r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), requestBody, options)
+	responseBody, location, err := r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), requestBody, options)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create resource", err.Error())
 		return
@@ -261,15 +261,10 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 			}
 		}
 	} else {
-		responseId := ""
-		if responseBody != nil {
-			if responseMap, ok := responseBody.(map[string]interface{}); ok {
-				if idValue, ok := responseMap["id"]; ok && idValue != nil {
-					if idString, ok := idValue.(string); ok {
-						responseId = idString
-					}
-				}
-			}
+		responseId, err := resolveResourceID(responseBody, location)
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to determine resource ID", err.Error())
+			return
 		}
 
 		model.Id = types.StringValue(responseId)
@@ -697,6 +692,30 @@ func buildOutputFromBody(body interface{}, paths map[string]string) attr.Value {
 		return nil
 	}
 	return out
+}
+
+// resolveResourceID returns the resource ID for a created resource: the response
+// body's top-level `id` when present, otherwise the last path segment of the
+// `Location` header (set by the client only for a synchronous 201 Created, so an
+// async 202 monitor URL is never used). Covers APIs keyed by a non-`id` field.
+// The result is verified
+// by the read of {url}/{id} that follows, so a wrong value fails loudly.
+func resolveResourceID(responseBody interface{}, location string) (string, error) {
+	if responseMap, ok := responseBody.(map[string]interface{}); ok {
+		if id, ok := responseMap["id"].(string); ok && id != "" {
+			return id, nil
+		}
+	}
+
+	if parsed, err := url.Parse(location); err == nil {
+		if trimmed := strings.TrimRight(parsed.Path, "/"); trimmed != "" {
+			if id := trimmed[strings.LastIndex(trimmed, "/")+1:]; id != "" {
+				return id, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("unable to determine the resource ID: the create response contained no top-level `id` field and no usable `Location` header")
 }
 
 func (r *MSGraphResource) MoveState(ctx context.Context) []resource.StateMover {

--- a/internal/services/msgraph_resource_collection.go
+++ b/internal/services/msgraph_resource_collection.go
@@ -300,7 +300,7 @@ func (r *MSGraphResourceCollection) applyCollection(ctx context.Context, model *
 	for _, item := range toAdd {
 		body := map[string]string{}
 		body["@odata.id"] = fmt.Sprintf("%s/%s/directoryObjects/%s", r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), item)
-		_, err := r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), body, clients.RequestOptions{RetryOptions: clients.NewRetryOptions(model.Retry)})
+		_, _, err := r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), body, clients.RequestOptions{RetryOptions: clients.NewRetryOptions(model.Retry)})
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/internal/services/msgraph_resource_internal_test.go
+++ b/internal/services/msgraph_resource_internal_test.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestResolveResourceID(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      interface{}
+		location  string
+		want      string
+		wantError *regexp.Regexp
+	}{
+		{
+			name: "uses response id field",
+			body: map[string]interface{}{"id": "00000000-0000-0000-0000-000000000000"},
+			want: "00000000-0000-0000-0000-000000000000",
+		},
+		{
+			name:     "response id wins over Location",
+			body:     map[string]interface{}{"id": "00000000-0000-0000-0000-000000000000"},
+			location: "https://graph.microsoft.com/v1.0/collection/22222222-2222-2222-2222-222222222222",
+			want:     "00000000-0000-0000-0000-000000000000",
+		},
+		{
+			name:     "derives id from Location header when body has no id (issue #107)",
+			body:     map[string]interface{}{"tenantId": "544a7a2e-697f-487c-b2b0-a13df7f346b6"},
+			location: "https://graph.microsoft.com/v1.0/79ac12ac-71ff-4533-a37b-08fdc0205d50/crossTenantAccessPolicyConfigurationPartners/544a7a2e-697f-487c-b2b0-a13df7f346b6",
+			want:     "544a7a2e-697f-487c-b2b0-a13df7f346b6",
+		},
+		{
+			name:     "Location header with query string and trailing slash",
+			body:     map[string]interface{}{},
+			location: "https://graph.microsoft.com/v1.0/things/abc123/?foo=bar",
+			want:     "abc123",
+		},
+		{
+			name:      "errors when nothing resolvable",
+			body:      map[string]interface{}{"tenantId": "544a7a2e-697f-487c-b2b0-a13df7f346b6"},
+			location:  "",
+			wantError: regexp.MustCompile(`unable to determine the resource ID`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveResourceID(tt.body, tt.location)
+			if tt.wantError != nil {
+				if err == nil {
+					t.Fatalf("expected error matching %q, got nil", tt.wantError.String())
+				}
+				if !tt.wantError.MatchString(err.Error()) {
+					t.Fatalf("expected error matching %q, got %q", tt.wantError.String(), err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
`msgraph_resource` read the resource ID only from the top-level `id` field in the Graph create response. Some APIs use a different key and return no `id`— for example `policies/crossTenantAccessPolicy/partners`, which is keyed by tenantId. The post-create check then failed with resource ID is empty, even though the resource was created in Entra.

### Fix
MSGraphClient.Create now also returns the Location header, captured only on a 201 Created. It's ignored on 202 Accepted since that points to an async monitor URL, not the resource.
Added `resolveResourceID`, which uses the response `id` when present and otherwise falls back to the last segment of Location. It returns an error when neither is available.

fix issue #107 