### PR TITLE
feat: Support `skip_destroy` in `msgraph_resource_collection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 - `msgraph_resource_collection`: Support resource import for collection resources (e.g. groups/{id}/members/$ref) to allow importing existing relationships into Terraform state.
+- `msgraph_resource_collection`: Added support for `skip_destroy` attribute to remove the resource from state without removing the references on destroy. This allows deleting a parent resource (such as a group) that would otherwise fail with constraints like "The group must have at least one owner, hence this owner cannot be removed." ([#78](https://github.com/microsoft/terraform-provider-msgraph/issues/78))
 
 ## 0.3.0
 

--- a/docs/resources/resource_collection.md
+++ b/docs/resources/resource_collection.md
@@ -104,6 +104,7 @@ Manage the full contents of a child reference collection (such as group members 
 
 To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 - `retry` (Attributes) The retry object supports the following attributes: (see [below for nested schema](#nestedatt--retry))
+- `skip_destroy` (Boolean) When `true`, destroying this resource removes it from Terraform state without calling Microsoft Graph to remove the references. Useful when the parent resource (e.g. a group whose owners/members these are) is destroyed in the same operation, since deleting the parent removes the references automatically. Defaults to `false`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/internal/services/msgraph_resource_collection.go
+++ b/internal/services/msgraph_resource_collection.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -46,6 +47,7 @@ type MSGraphResourceCollectionModel struct {
 	ApiVersion           types.String      `tfsdk:"api_version"`
 	Url                  types.String      `tfsdk:"url"`
 	ReferenceIds         types.List        `tfsdk:"reference_ids"`
+	SkipDestroy          types.Bool        `tfsdk:"skip_destroy"`
 	ReadQueryParameters  types.Map         `tfsdk:"read_query_parameters"`
 	Retry                retry.Value       `tfsdk:"retry"`
 	ResponseExportValues map[string]string `tfsdk:"response_export_values"`
@@ -93,6 +95,13 @@ func (r *MSGraphResourceCollection) Schema(ctx context.Context, req resource.Sch
 				ElementType:         types.StringType,
 				Optional:            true,
 				PlanModifiers:       []planmodifier.List{myplanmodifier.OrderInsensitiveStringList()},
+			},
+
+			"skip_destroy": schema.BoolAttribute{
+				MarkdownDescription: "When `true`, destroying this resource removes it from Terraform state without calling Microsoft Graph to remove the references. Useful when the parent resource (e.g. a group whose owners/members these are) is destroyed in the same operation, since deleting the parent removes the references automatically. Defaults to `false`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 
 			"read_query_parameters": schema.MapAttribute{
@@ -259,6 +268,11 @@ func (r *MSGraphResourceCollection) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
+	if model.SkipDestroy.ValueBool() {
+		tflog.Info(ctx, "skip_destroy is set to true; removing collection from state without removing references")
+		return
+	}
+
 	timeout, diags := model.Timeouts.Delete(ctx, 30*time.Minute)
 	resp.Diagnostics.Append(diags...)
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -367,6 +381,7 @@ func (r *MSGraphResourceCollection) ImportState(ctx context.Context, req resourc
 		Url:                 types.StringValue(urlValue),
 		ApiVersion:          types.StringValue(apiVersion),
 		ReferenceIds:        types.ListNull(types.StringType),
+		SkipDestroy:         types.BoolValue(false),
 		ReadQueryParameters: types.MapNull(types.ListType{ElemType: types.StringType}),
 		Retry:               retry.NewValueNull(),
 		Timeouts: timeouts.Value{

--- a/internal/services/msgraph_resource_collection_test.go
+++ b/internal/services/msgraph_resource_collection_test.go
@@ -34,6 +34,22 @@ func TestAcc_ResourceCollectionBasic(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceCollectionSkipDestroy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "msgraph_resource_collection", "test")
+	r := MSGraphTestResourceCollection{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.skipDestroyOwners(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Exists(r),
+				resource.TestCheckResourceAttr(data.ResourceName, "reference_ids.#", "1"),
+				resource.TestCheckResourceAttr(data.ResourceName, "skip_destroy", "true"),
+			),
+		},
+	})
+}
+
 func TestAcc_ResourceCollectionUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "msgraph_resource_collection", "test")
 	r := MSGraphTestResourceCollection{}
@@ -240,6 +256,43 @@ resource "msgraph_resource_collection" "test" {
   url           = "groups/${msgraph_resource.group.id}/members/$ref"
   api_version   = "beta"
   reference_ids = [msgraph_resource.sp_a.id]
+}
+`
+}
+
+func (r MSGraphTestResourceCollection) skipDestroyOwners() string {
+	return `
+resource "msgraph_resource" "application_a" {
+  url = "applications"
+  body = {
+    displayName = "Collection App a"
+  }
+  response_export_values = {
+    appId = "appId"
+  }
+}
+
+resource "msgraph_resource" "sp_a" {
+  url = "servicePrincipals"
+  body = {
+    appId = msgraph_resource.application_a.output.appId
+  }
+}
+
+resource "msgraph_resource" "group" {
+  url = "groups"
+  body = {
+    displayName     = "Collection Group Skip Destroy"
+    mailEnabled     = false
+    mailNickname    = "collection-group-skip-destroy"
+    securityEnabled = true
+  }
+}
+
+resource "msgraph_resource_collection" "test" {
+  url           = "groups/${msgraph_resource.group.id}/owners/$ref"
+  reference_ids = [msgraph_resource.sp_a.id]
+  skip_destroy  = true
 }
 `
 }

--- a/internal/services/msgraph_resource_collection_test.go
+++ b/internal/services/msgraph_resource_collection_test.go
@@ -291,6 +291,7 @@ resource "msgraph_resource" "group" {
 
 resource "msgraph_resource_collection" "test" {
   url           = "groups/${msgraph_resource.group.id}/owners/$ref"
+  api_version   = "beta"
   reference_ids = [msgraph_resource.sp_a.id]
   skip_destroy  = true
 }


### PR DESCRIPTION
### Problem
Deleting a group that has owners fails. On destroy, `msgraph_resource_collection` removes the references before the parent group is deleted, and Microsoft Graph rejects removing the last owner:
```
The group must have at least one owner, hence this owner cannot be removed.
```
Because Terraform destroys the collection (child) before the group (parent), the group can never be torn down through Terraform.

### Change
Add a `skip_destroy` attribute (default false). When `true`, destroying the collection removes it from state without calling Graph to remove the references. The parent's deletion then removes the references automatically, avoiding the constraint.

This matches how azuread_group deletes a group without pre-removing owners. It also helps users manage collections dynamically.

### Tests
Added `TestAcc_ResourceCollectionSkipDestroy` covering apply + destroy of a group-owners collection with skip_destroy = true.

Fixes #78 