### PR TITLE
fix: apply retry policy by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ ENHANCEMENTS:
 - `msgraph_resource_collection`: Added support for `skip_destroy` attribute to remove the resource from state without removing the references on destroy. This allows deleting a parent resource (such as a group) that would otherwise fail with constraints like "The group must have at least one owner, hence this owner cannot be removed." ([#78](https://github.com/microsoft/terraform-provider-msgraph/issues/78))
 
 BUG FIXES:
-- Fixed an issue where the post-creation existence check did not apply the retry policy, causing transient errors such as `429 Too Many Requests` to fail the apply instead of being retried ([#129](https://github.com/microsoft/terraform-provider-msgraph/issues/129))
+- Fixed an issue where transient errors such as `429 Too Many Requests` were not retried during create, delete, and the create/delete consistency checks, causing operations to fail under throttling. Retry of transient failures (`429` and `5xx`) is now applied by default regardless of whether a `retry` block is configured ([#129](https://github.com/microsoft/terraform-provider-msgraph/issues/129))
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ENHANCEMENTS:
 - `msgraph_resource_collection`: Support resource import for collection resources (e.g. groups/{id}/members/$ref) to allow importing existing relationships into Terraform state.
 - `msgraph_resource_collection`: Added support for `skip_destroy` attribute to remove the resource from state without removing the references on destroy. This allows deleting a parent resource (such as a group) that would otherwise fail with constraints like "The group must have at least one owner, hence this owner cannot be removed." ([#78](https://github.com/microsoft/terraform-provider-msgraph/issues/78))
+- Retry of transient failures (`429` and `5xx` ) is now applied by default regardless of whether a `retry` block is configured.
 
 BUG FIXES:
-- Fixed an issue where transient errors such as `429 Too Many Requests` were not retried during create, delete, and the create/delete consistency checks, causing operations to fail under throttling. Retry of transient failures (`429` and `5xx`) is now applied by default regardless of whether a `retry` block is configured ([#129](https://github.com/microsoft/terraform-provider-msgraph/issues/129))
+- Fixed an issue where transient errors such as `429 Too Many Requests` were not retried during create, delete, and the create/delete consistency checks, causing operations to fail under throttling. ([#129](https://github.com/microsoft/terraform-provider-msgraph/issues/129))
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ENHANCEMENTS:
 - `msgraph_resource_collection`: Support resource import for collection resources (e.g. groups/{id}/members/$ref) to allow importing existing relationships into Terraform state.
 - `msgraph_resource_collection`: Added support for `skip_destroy` attribute to remove the resource from state without removing the references on destroy. This allows deleting a parent resource (such as a group) that would otherwise fail with constraints like "The group must have at least one owner, hence this owner cannot be removed." ([#78](https://github.com/microsoft/terraform-provider-msgraph/issues/78))
-- Retry of transient failures (`429` and `5xx` ) is now applied by default regardless of whether a `retry` block is configured.
+- Retry of transient failures (`429` and `5xx`) is now applied by default regardless of whether a `retry` block is configured.
 
 BUG FIXES:
 - Fixed an issue where transient errors such as `429 Too Many Requests` were not retried during create, delete, and the create/delete consistency checks, causing operations to fail under throttling. ([#129](https://github.com/microsoft/terraform-provider-msgraph/issues/129))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ENHANCEMENTS:
 - `msgraph_resource_collection`: Support resource import for collection resources (e.g. groups/{id}/members/$ref) to allow importing existing relationships into Terraform state.
 - `msgraph_resource_collection`: Added support for `skip_destroy` attribute to remove the resource from state without removing the references on destroy. This allows deleting a parent resource (such as a group) that would otherwise fail with constraints like "The group must have at least one owner, hence this owner cannot be removed." ([#78](https://github.com/microsoft/terraform-provider-msgraph/issues/78))
-- Retry of transient failures (`429` and `5xx`) is now applied by default regardless of whether a `retry` block is configured.
+- Retry of transient failures (`429`, `408`, `500`, `502`, `503` and `504`) is now applied by default regardless of whether a `retry` block is configured.
 
 BUG FIXES:
 - Fixed an issue where transient errors such as `429 Too Many Requests` were not retried during create, delete, and the create/delete consistency checks, causing operations to fail under throttling. ([#129](https://github.com/microsoft/terraform-provider-msgraph/issues/129))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ ENHANCEMENTS:
 - `msgraph_resource_collection`: Support resource import for collection resources (e.g. groups/{id}/members/$ref) to allow importing existing relationships into Terraform state.
 - `msgraph_resource_collection`: Added support for `skip_destroy` attribute to remove the resource from state without removing the references on destroy. This allows deleting a parent resource (such as a group) that would otherwise fail with constraints like "The group must have at least one owner, hence this owner cannot be removed." ([#78](https://github.com/microsoft/terraform-provider-msgraph/issues/78))
 
+BUG FIXES:
+- Fixed an issue where the post-creation existence check did not apply the retry policy, causing transient errors such as `429 Too Many Requests` to fail the apply instead of being retried ([#129](https://github.com/microsoft/terraform-provider-msgraph/issues/129))
+
 ## 0.3.0
 
 FEATURES:

--- a/docs/data-sources/resource.md
+++ b/docs/data-sources/resource.md
@@ -99,7 +99,7 @@ To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 
 Required:
 
-- `error_message_regex` (List of String) A list of regular expressions to match against error messages. If any of the regular expressions match, the request will be retried.
+- `error_message_regex` (List of String) A list of regular expressions matched against error messages to trigger a retry. Transient HTTP errors (408, 429, 500, 502, 503, and 504) are always retried regardless of this setting; use this to retry on additional, non-transient errors.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/data-sources/resource_action.md
+++ b/docs/data-sources/resource_action.md
@@ -166,7 +166,7 @@ To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 
 Required:
 
-- `error_message_regex` (List of String) A list of regular expressions to match against error messages. If any of the regular expressions match, the request will be retried.
+- `error_message_regex` (List of String) A list of regular expressions matched against error messages to trigger a retry. Transient HTTP errors (408, 429, 500, 502, 503, and 504) are always retried regardless of this setting; use this to retry on additional, non-transient errors.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -118,7 +118,7 @@ To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 
 Required:
 
-- `error_message_regex` (List of String) A list of regular expressions to match against error messages. If any of the regular expressions match, the request will be retried.
+- `error_message_regex` (List of String) A list of regular expressions matched against error messages to trigger a retry. Transient HTTP errors (408, 429, 500, 502, 503, and 504) are always retried regardless of this setting; use this to retry on additional, non-transient errors.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/resource_action.md
+++ b/docs/resources/resource_action.md
@@ -185,7 +185,7 @@ To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 
 Required:
 
-- `error_message_regex` (List of String) A list of regular expressions to match against error messages. If any of the regular expressions match, the request will be retried.
+- `error_message_regex` (List of String) A list of regular expressions matched against error messages to trigger a retry. Transient HTTP errors (408, 429, 500, 502, 503, and 504) are always retried regardless of this setting; use this to retry on additional, non-transient errors.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/resource_collection.md
+++ b/docs/resources/resource_collection.md
@@ -129,7 +129,7 @@ To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 
 Required:
 
-- `error_message_regex` (List of String) A list of regular expressions to match against error messages. If any of the regular expressions match, the request will be retried.
+- `error_message_regex` (List of String) A list of regular expressions matched against error messages to trigger a retry. Transient HTTP errors (408, 429, 500, 502, 503, and 504) are always retried regardless of this setting; use this to retry on additional, non-transient errors.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/update_resource.md
+++ b/docs/resources/update_resource.md
@@ -112,7 +112,7 @@ To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 
 Required:
 
-- `error_message_regex` (List of String) A list of regular expressions to match against error messages. If any of the regular expressions match, the request will be retried.
+- `error_message_regex` (List of String) A list of regular expressions matched against error messages to trigger a retry. Transient HTTP errors (408, 429, 500, 502, 503, and 504) are always retried regardless of this setting; use this to retry on additional, non-transient errors.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"log"
+	"math"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -91,6 +92,16 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 			IncludeBody:        false,
 			AllowedHeaders:     allowedHeaders,
 			AllowedQueryParams: allowedQueryParams,
+		},
+		// Baseline retry policy applied to every request: retry transient failures
+		// (429 and 5xx) using azcore's built-in status-code matching. MaxRetries is set
+		// very high so the effective retry budget is bounded by each operation's context
+		// deadline rather than a fixed count. Per-request overrides (user-configured
+		// `retry` regex and read-after-create 404/403 handling) are layered on top via
+		// policy.WithRetryOptions at the call site.
+		Retry: policy.RetryOptions{
+			MaxRetries:  math.MaxInt16,
+			StatusCodes: DefaultRetryableStatusCodes,
 		},
 		PerCallPolicies:  perCallPolicies,
 		PerRetryPolicies: perRetryPolicies,

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -94,7 +94,7 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 			AllowedQueryParams: allowedQueryParams,
 		},
 		// Baseline retry policy applied to every request: retry transient failures
-		// (429 and 5xx) using azcore's built-in status-code matching. MaxRetries is set
+		// using azcore's built-in status-code matching. MaxRetries is set
 		// very high so the effective retry budget is bounded by each operation's context
 		// deadline rather than a fixed count. Per-request overrides (user-configured
 		// `retry` regex and read-after-create 404/403 handling) are layered on top via

--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -112,9 +112,11 @@ func NewRetryOptionsForReadAfterCreate() *policy.RetryOptions {
 		ShouldRetry: func(resp *http.Response, err error) bool {
 			// We need to test for status codes here too. This covers the case that these options are combined with
 			// retry options from NewRetryOptions, because the ShouldRetry function takes precedence over StatusCodes.
-			for _, code := range statusCodes {
-				if resp.StatusCode == code {
-					return true
+			if resp != nil {
+				for _, code := range statusCodes {
+					if resp.StatusCode == code {
+						return true
+					}
 				}
 			}
 			return false
@@ -122,11 +124,13 @@ func NewRetryOptionsForReadAfterCreate() *policy.RetryOptions {
 	}
 }
 
-// NewRetryOptions returns a RetryOptions that retries transient failures (429 and
-// 5xx) with a high retry count bounded by the context deadline.
+// NewRetryOptions creates a RetryOptions based on the provided retry.RetryValue.
 func NewRetryOptions(rtry retry.Value) *policy.RetryOptions {
-	userConfigured := !rtry.IsNull() && !rtry.IsUnknown()
+	if rtry.IsNull() || rtry.IsUnknown() {
+		return nil
+	}
 
+	log.Printf("[DEBUG] Using custom retry configuration")
 	return &policy.RetryOptions{
 		// Set a very high max retries to make sure context deadline is respected.
 		MaxRetries:  math.MaxInt16,
@@ -139,10 +143,8 @@ func NewRetryOptions(rtry retry.Value) *policy.RetryOptions {
 				}
 			}
 
-			if !userConfigured {
-				return false
-			}
-
+			// Get the error message to check against regex patterns,
+			// If use the err.Error() string first, else get the response error from the HTTP response.
 			var errorMsg string
 			if err != nil {
 				errorMsg = err.Error()
@@ -152,6 +154,7 @@ func NewRetryOptions(rtry retry.Value) *policy.RetryOptions {
 					errorMsg = responseErr.Error()
 				}
 			}
+			// Check if the error message matches any of the retryable error regexps
 			if errorMsg == "" {
 				return false
 			}

--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -122,13 +122,11 @@ func NewRetryOptionsForReadAfterCreate() *policy.RetryOptions {
 	}
 }
 
-// NewRetryOptions creates a RetryOptions based on the provided retry.RetryValue.
+// NewRetryOptions returns a RetryOptions that retries transient failures (429 and
+// 5xx) with a high retry count bounded by the context deadline.
 func NewRetryOptions(rtry retry.Value) *policy.RetryOptions {
-	if rtry.IsNull() || rtry.IsUnknown() {
-		return nil
-	}
+	userConfigured := !rtry.IsNull() && !rtry.IsUnknown()
 
-	log.Printf("[DEBUG] Using custom retry configuration")
 	return &policy.RetryOptions{
 		// Set a very high max retries to make sure context deadline is respected.
 		MaxRetries:  math.MaxInt16,
@@ -141,8 +139,10 @@ func NewRetryOptions(rtry retry.Value) *policy.RetryOptions {
 				}
 			}
 
-			// Get the error message to check against regex patterns,
-			// If use the err.Error() string first, else get the response error from the HTTP response.
+			if !userConfigured {
+				return false
+			}
+
 			var errorMsg string
 			if err != nil {
 				errorMsg = err.Error()
@@ -152,7 +152,6 @@ func NewRetryOptions(rtry retry.Value) *policy.RetryOptions {
 					errorMsg = responseErr.Error()
 				}
 			}
-			// Check if the error message matches any of the retryable error regexps
 			if errorMsg == "" {
 				return false
 			}

--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -112,11 +112,13 @@ func NewRetryOptionsForReadAfterCreate() *policy.RetryOptions {
 		ShouldRetry: func(resp *http.Response, err error) bool {
 			// We need to test for status codes here too. This covers the case that these options are combined with
 			// retry options from NewRetryOptions, because the ShouldRetry function takes precedence over StatusCodes.
-			if resp != nil {
-				for _, code := range statusCodes {
-					if resp.StatusCode == code {
-						return true
-					}
+			if resp == nil {
+				return err != nil
+			}
+
+			for _, code := range statusCodes {
+				if resp.StatusCode == code {
+					return true
 				}
 			}
 			return false
@@ -136,7 +138,10 @@ func NewRetryOptions(rtry retry.Value) *policy.RetryOptions {
 		MaxRetries:  math.MaxInt16,
 		StatusCodes: DefaultRetryableStatusCodes,
 		ShouldRetry: func(resp *http.Response, err error) bool {
-			// We need to test for DefaultRetryableStatusCodes here as using ShouldRetry overrides the use of StatusCodes.
+			if resp == nil {
+				return err != nil
+			}
+
 			for _, code := range DefaultRetryableStatusCodes {
 				if resp.StatusCode == code {
 					return true

--- a/internal/retry/schema.go
+++ b/internal/retry/schema.go
@@ -16,8 +16,8 @@ func Schema(ctx context.Context) schema.Attribute {
 			"error_message_regex": schema.ListAttribute{
 				ElementType:         types.StringType,
 				Required:            true,
-				Description:         "A list of regular expressions to match against error messages. If any of the regular expressions match, the request will be retried.",
-				MarkdownDescription: "A list of regular expressions to match against error messages. If any of the regular expressions match, the request will be retried.",
+				Description:         "A list of regular expressions matched against error messages to trigger a retry. Transient HTTP errors (408, 429, 500, 502, 503, and 504) are always retried regardless of this setting; use this to retry on additional, non-transient errors.",
+				MarkdownDescription: "A list of regular expressions matched against error messages to trigger a retry. Transient HTTP errors (408, 429, 500, 502, 503, and 504) are always retried regardless of this setting; use this to retry on additional, non-transient errors.",
 				Validators: []validator.List{
 					listvalidator.ValueStringsAre(myvalidator.StringIsValidRegex()),
 					listvalidator.UniqueValues(),

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -273,7 +273,7 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Wait for the resource to be available
-	if err = consistency.WaitForUpdate(ctx, ResourceExistenceFunc(r.client, model)); err != nil {
+	if err = consistency.WaitForUpdate(ctx, ResourceExistenceFunc(r.client, model, true)); err != nil {
 		resp.Diagnostics.AddError("Error", fmt.Sprintf("waiting for creation of %s: %v", model.Url.ValueString(), err))
 		return
 	}
@@ -363,7 +363,7 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	// Wait for the resource to be available
-	if err := consistency.WaitForUpdate(ctx, ResourceExistenceFunc(r.client, model)); err != nil {
+	if err := consistency.WaitForUpdate(ctx, ResourceExistenceFunc(r.client, model, false)); err != nil {
 		resp.Diagnostics.AddError("Error", fmt.Sprintf("waiting for creation of %s: %v", model.Url.ValueString(), err))
 		return
 	}
@@ -540,12 +540,12 @@ func (r *MSGraphResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	// Wait for deletion to complete
-	if err = consistency.WaitForDeletion(ctx, ResourceExistenceFunc(r.client, model)); err != nil {
+	if err = consistency.WaitForDeletion(ctx, ResourceExistenceFunc(r.client, model, false)); err != nil {
 		resp.Diagnostics.AddError("Error waiting for deletion", err.Error())
 	}
 }
 
-func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResourceModel) consistency.ChangeFunc {
+func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResourceModel, readAfterCreate bool) consistency.ChangeFunc {
 	return func(ctx context.Context) (*bool, error) {
 		if model == nil {
 			return nil, fmt.Errorf("model is nil")
@@ -560,10 +560,19 @@ func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResource
 			return nil, fmt.Errorf("resource URL is empty")
 		}
 
+		retryOptions := clients.NewRetryOptions(model.Retry)
+		if readAfterCreate {
+			retryOptions = clients.CombineRetryOptions(
+				clients.NewRetryOptionsForReadAfterCreate(),
+				clients.NewRetryOptions(model.Retry),
+			)
+		}
+
 		if strings.HasSuffix(model.Url.ValueString(), "/$ref") {
 			collectionUrl := baseCollectionUrl(model.Url.ValueString())
 			options := clients.RequestOptions{
 				QueryParameters: clients.NewQueryParameters(AsMapOfLists(model.ReadQueryParameters)),
+				RetryOptions:    retryOptions,
 			}
 			referenceIds, err := client.ListRefIDs(ctx, collectionUrl, model.ApiVersion.ValueString(), options)
 			if err != nil {
@@ -585,6 +594,7 @@ func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResource
 
 		options := clients.RequestOptions{
 			QueryParameters: clients.NewQueryParameters(AsMapOfLists(model.ReadQueryParameters)),
+			RetryOptions:    retryOptions,
 		}
 		itemUrl := fmt.Sprintf("%s/%s", model.Url.ValueString(), model.Id.ValueString())
 		_, err := client.Read(ctx, itemUrl, model.ApiVersion.ValueString(), options)

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -364,7 +364,7 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	// Wait for the resource to be available
 	if err := consistency.WaitForUpdate(ctx, ResourceExistenceFunc(r.client, model, false)); err != nil {
-		resp.Diagnostics.AddError("Error", fmt.Sprintf("waiting for creation of %s: %v", model.Url.ValueString(), err))
+		resp.Diagnostics.AddError("Error", fmt.Sprintf("waiting for update of %s: %v", model.Url.ValueString(), err))
 		return
 	}
 

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -564,7 +564,7 @@ func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResource
 		if readAfterCreate {
 			retryOptions = clients.CombineRetryOptions(
 				clients.NewRetryOptionsForReadAfterCreate(),
-				clients.NewRetryOptions(model.Retry),
+				retryOptions,
 			)
 		}
 

--- a/internal/services/msgraph_resource_collection.go
+++ b/internal/services/msgraph_resource_collection.go
@@ -177,7 +177,10 @@ func (r *MSGraphResourceCollection) Create(ctx context.Context, req resource.Cre
 	base := baseCollectionUrl(model.Url.ValueString())
 	opts := clients.RequestOptions{
 		QueryParameters: clients.NewQueryParameters(AsMapOfLists(model.ReadQueryParameters)),
-		RetryOptions:    clients.NewRetryOptions(model.Retry),
+		RetryOptions: clients.CombineRetryOptions(
+			clients.NewRetryOptionsForReadAfterCreate(),
+			clients.NewRetryOptions(model.Retry),
+		),
 	}
 	body, err := r.client.List(ctx, base, model.ApiVersion.ValueString(), opts)
 	if err != nil {

--- a/internal/services/msgraph_resource_test.go
+++ b/internal/services/msgraph_resource_test.go
@@ -156,6 +156,26 @@ func TestAcc_ResourceRetry(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceRetryOnThrottle(t *testing.T) {
+	data := acceptance.BuildTestData(t, "msgraph_resource", "test")
+
+	r := MSGraphTestResource{}
+
+	const count = 60
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.throttleRetry(data, count),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(fmt.Sprintf("%s.0", data.ResourceName)).Exists(r),
+				check.That(fmt.Sprintf("%s.0", data.ResourceName)).Key("id").IsUUID(),
+				check.That(fmt.Sprintf("%s.%d", data.ResourceName, count-1)).Exists(r),
+				check.That(fmt.Sprintf("%s.%d", data.ResourceName, count-1)).Key("id").IsUUID(),
+			),
+		},
+	})
+}
+
 func TestAcc_ResourceTimeouts_Create(t *testing.T) {
 	data := acceptance.BuildTestData(t, "msgraph_resource", "test")
 
@@ -451,6 +471,29 @@ resource "msgraph_resource" "test" {
     ]
   }
 }`
+}
+
+func (r MSGraphTestResource) throttleRetry(data acceptance.TestData, count int) string {
+	return fmt.Sprintf(`
+resource "msgraph_resource" "test" {
+  count = %[1]d
+
+  url         = "identity/conditionalAccess/namedLocations"
+  api_version = "beta"
+
+  body = {
+    "@odata.type" = "#microsoft.graph.ipNamedLocation"
+    displayName   = "acctest-retry-%[2]d-${count.index}"
+    isTrusted     = false
+    ipRanges = [
+      {
+        "@odata.type" = "#microsoft.graph.iPv4CidrRange"
+        cidrAddress = "203.0.113.${count.index %% 254 + 1}/32"
+      }
+    ]
+  }
+}
+`, count, data.RandomInteger)
 }
 
 func (r MSGraphTestResource) withCreateTimeout() string {

--- a/internal/services/msgraph_resource_test.go
+++ b/internal/services/msgraph_resource_test.go
@@ -165,7 +165,7 @@ func TestAcc_ResourceRetryOnThrottle(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.throttleRetry(data, count),
+			Config: r.throttleRetry(count),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(fmt.Sprintf("%s.0", data.ResourceName)).Exists(r),
 				check.That(fmt.Sprintf("%s.0", data.ResourceName)).Key("id").IsUUID(),
@@ -473,27 +473,27 @@ resource "msgraph_resource" "test" {
 }`
 }
 
-func (r MSGraphTestResource) throttleRetry(data acceptance.TestData, count int) string {
+func (r MSGraphTestResource) throttleRetry(count int) string {
 	return fmt.Sprintf(`
 resource "msgraph_resource" "test" {
-  count = %[1]d
+  count = %d
 
   url         = "identity/conditionalAccess/namedLocations"
   api_version = "beta"
 
   body = {
     "@odata.type" = "#microsoft.graph.ipNamedLocation"
-    displayName   = "acctest-retry-%[2]d-${count.index}"
+    displayName   = "acctest-retry-${count.index}"
     isTrusted     = false
     ipRanges = [
       {
         "@odata.type" = "#microsoft.graph.iPv4CidrRange"
-        cidrAddress = "203.0.113.${count.index %% 254 + 1}/32"
+        cidrAddress   = "203.0.113.${count.index + 1}/32"
       }
     ]
   }
 }
-`, count, data.RandomInteger)
+`, count)
 }
 
 func (r MSGraphTestResource) withCreateTimeout() string {

--- a/internal/services/msgraph_resource_test.go
+++ b/internal/services/msgraph_resource_test.go
@@ -161,16 +161,14 @@ func TestAcc_ResourceRetryOnThrottle(t *testing.T) {
 
 	r := MSGraphTestResource{}
 
-	const count = 60
-
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.throttleRetry(count),
+			Config: r.throttleRetry(60),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(fmt.Sprintf("%s.0", data.ResourceName)).Exists(r),
 				check.That(fmt.Sprintf("%s.0", data.ResourceName)).Key("id").IsUUID(),
-				check.That(fmt.Sprintf("%s.%d", data.ResourceName, count-1)).Exists(r),
-				check.That(fmt.Sprintf("%s.%d", data.ResourceName, count-1)).Key("id").IsUUID(),
+				check.That(fmt.Sprintf("%s.%d", data.ResourceName, 59)).Exists(r),
+				check.That(fmt.Sprintf("%s.%d", data.ResourceName, 59)).Key("id").IsUUID(),
 			),
 		},
 	})

--- a/internal/services/msgraph_update_resource.go
+++ b/internal/services/msgraph_update_resource.go
@@ -239,7 +239,7 @@ func (r *MSGraphUpdateResource) CreateUpdate(ctx context.Context, plan tfsdk.Pla
 	if isCreate {
 		readRetryOptions = clients.CombineRetryOptions(
 			clients.NewRetryOptionsForReadAfterCreate(),
-			clients.NewRetryOptions(model.Retry),
+			readRetryOptions,
 		)
 	}
 	options = clients.RequestOptions{

--- a/internal/services/msgraph_update_resource.go
+++ b/internal/services/msgraph_update_resource.go
@@ -235,9 +235,16 @@ func (r *MSGraphUpdateResource) CreateUpdate(ctx context.Context, plan tfsdk.Pla
 		return
 	}
 
+	readRetryOptions := clients.NewRetryOptions(model.Retry)
+	if isCreate {
+		readRetryOptions = clients.CombineRetryOptions(
+			clients.NewRetryOptionsForReadAfterCreate(),
+			clients.NewRetryOptions(model.Retry),
+		)
+	}
 	options = clients.RequestOptions{
 		QueryParameters: clients.NewQueryParameters(AsMapOfLists(model.ReadQueryParameters)),
-		RetryOptions:    clients.NewRetryOptions(model.Retry),
+		RetryOptions:    readRetryOptions,
 	}
 	responseBody, err := r.client.Read(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), options)
 	if err != nil {


### PR DESCRIPTION
## Description

Under sustained throttling, `429 Too Many Requests` errors caused hard failures during create, delete, and the consistency checks that wait for a resource to appear or disappear. These paths only retried when a user configured a `retry` block; otherwise they fell back to azcore's default of 3 retries.

This makes transient-failure retry a default for every request:

- **Baseline** (`client.go`): all requests retry `408`, `429`/`5xx`, bounded by the operation timeout rather than a fixed retry count.
- **Per-request** (`options.go`): user `retry` regex and read-after-create `404`/`403` handling are layered on top as before.

Also fixes a nil-pointer panic in `ShouldRetry`, which dereferenced the HTTP response without a nil check and could crash on transport errors (e.g. connection reset) where the response is nil.

## Tests

- `TestAcc_ResourceRetryOnThrottle`: creates a burst of resources in parallel against an endpoint throttled at ~1 req/sec (no `retry` block) to confirm the default retry recovers and all resources land in state.

Fixes #129, #98