### PR TITLE
fix: Send full nested object on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 BUG FIXES:
 - `msgraph_resource`: Fixed an issue where updating a nested object (complex type) sent only the changed sub-fields, causing Microsoft Graph to reset omitted siblings to their defaults. The provider now sends the full nested object when any of its fields change (e.g. `federatedIdentityCredential.claimsMatchingExpression`). ([#137](https://github.com/microsoft/terraform-provider-msgraph/issues/137))
 
-
 ## 0.4.0
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+BUG FIXES:
+- `msgraph_resource`: Fixed an issue where updating a nested object (complex type) sent only the changed sub-fields, causing Microsoft Graph to reset omitted siblings to their defaults. The provider now sends the full nested object when any of its fields change (e.g. `federatedIdentityCredential.claimsMatchingExpression`). ([#137](https://github.com/microsoft/terraform-provider-msgraph/issues/137))
+
+
 ## 0.4.0
 
 ENHANCEMENTS:

--- a/internal/services/msgraph_resource_test.go
+++ b/internal/services/msgraph_resource_test.go
@@ -262,6 +262,29 @@ func TestAcc_ResourceWithPutUpdateMethod(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceFederatedIdentityCredentialClaimsExpression(t *testing.T) {
+	data := acceptance.BuildTestData(t, "msgraph_resource", "test")
+
+	r := MSGraphTestResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.federatedIdentityCredentialClaimsExpression("claims['sub'] matches 'repo:contoso/*'"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Exists(r),
+				check.That(data.ResourceName).Key("id").IsUUID(),
+			),
+		},
+		{
+			Config: r.federatedIdentityCredentialClaimsExpression("claims['sub'] matches 'repo:contoso@123456/*'"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Exists(r),
+				check.That(data.ResourceName).Key("id").IsUUID(),
+			),
+		},
+	})
+}
+
 func TestAcc_ResourceImport_InvalidIDFormat(t *testing.T) {
 	data := acceptance.BuildTestData(t, "msgraph_resource", "test")
 
@@ -645,6 +668,32 @@ resource "msgraph_resource" "test" {
   }
 }
 `, displayName)
+}
+
+func (r MSGraphTestResource) federatedIdentityCredentialClaimsExpression(value string) string {
+	return fmt.Sprintf(`
+resource "msgraph_resource" "application" {
+  url         = "applications"
+  api_version = "beta"
+  body = {
+    displayName = "acctest-fic-claims-app"
+  }
+}
+
+resource "msgraph_resource" "test" {
+  url         = "applications/${msgraph_resource.application.id}/federatedIdentityCredentials"
+  api_version = "beta"
+  body = {
+    name      = "acctest-github-federated-oidc"
+    issuer    = "https://token.actions.githubusercontent.com"
+    audiences = ["api://AzureADTokenExchange"]
+    claimsMatchingExpression = {
+      value           = "%s"
+      languageVersion = 1
+    }
+  }
+}
+`, value)
 }
 
 func (r MSGraphTestResource) applicationWithPasswordCredentials(enabled bool) string {

--- a/internal/services/msgraph_resource_test.go
+++ b/internal/services/msgraph_resource_test.go
@@ -269,14 +269,14 @@ func TestAcc_ResourceFederatedIdentityCredentialClaimsExpression(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.federatedIdentityCredentialClaimsExpression("claims['sub'] matches 'repo:contoso/*'"),
+			Config: r.federatedIdentityCredentialClaimsExpression("claims['sub'] matches 'repo:contoso/*' and claims['repository_id'] eq '123456'"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Exists(r),
 				check.That(data.ResourceName).Key("id").IsUUID(),
 			),
 		},
 		{
-			Config: r.federatedIdentityCredentialClaimsExpression("claims['sub'] matches 'repo:contoso@123456/*'"),
+			Config: r.federatedIdentityCredentialClaimsExpression("claims['sub'] matches 'repo:contoso/contoso-repo:*' and claims['repository_id'] eq '123456'"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Exists(r),
 				check.That(data.ResourceName).Key("id").IsUUID(),

--- a/internal/utils/json.go
+++ b/internal/utils/json.go
@@ -71,6 +71,16 @@ type UpdateJsonOption struct {
 	IgnoreNullProperty    bool
 }
 
+// isRedactedString reports whether s is a placeholder that Graph returned instead of the
+// real value, and therefore must never be written back. An empty string is included
+// because Graph omits or blanks out several write-only properties on read.
+func isRedactedString(s string, option UpdateJsonOption) bool {
+	if !option.IgnoreMissingProperty {
+		return false
+	}
+	return regexp.MustCompile(`^\*+$`).MatchString(s) || s == "<redacted>" || s == ""
+}
+
 // UpdateObject is used to get an updated object which has same schema as old, but with new value
 func UpdateObject(old interface{}, new interface{}, option UpdateJsonOption) interface{} {
 	if reflect.DeepEqual(old, new) {
@@ -147,7 +157,7 @@ func UpdateObject(old interface{}, new interface{}, option UpdateJsonOption) int
 			if option.IgnoreCasing && strings.EqualFold(oldValue, newStr) {
 				return oldValue
 			}
-			if option.IgnoreMissingProperty && (regexp.MustCompile(`^\*+$`).MatchString(newStr) || newStr == "<redacted>" || newStr == "") {
+			if isRedactedString(newStr, option) {
 				return oldValue
 			}
 		}
@@ -240,7 +250,7 @@ func DiffObject(old interface{}, new interface{}, option UpdateJsonOption) inter
 				case isJSONObject(newVal):
 					// Complex-type property. Graph replaces the whole object on
 					// PATCH, so when it changed we must send it in full (issue #137).
-					if !reflect.DeepEqual(oldVal, newVal) {
+					if DiffObject(oldVal, newVal, option) != nil {
 						if v, keep := fullValueForPatch(newVal, option); keep {
 							res[key] = v
 						}
@@ -284,7 +294,7 @@ func DiffObject(old interface{}, new interface{}, option UpdateJsonOption) inter
 			if option.IgnoreCasing && strings.EqualFold(oldValue, newStr) {
 				return nil
 			}
-			if option.IgnoreMissingProperty && (regexp.MustCompile(`^\*+$`).MatchString(newStr) || newStr == "<redacted>" || newStr == "") {
+			if isRedactedString(newStr, option) {
 				return nil
 			}
 		}
@@ -302,9 +312,11 @@ func isJSONObject(v interface{}) bool {
 // fullValueForPatch returns the value to include in a PATCH body when a property must
 // be sent in full (a Graph complex type, or a newly added property). It preserves the
 // entire value but drops redacted/placeholder string leaves when IgnoreMissingProperty
-// is set, so secrets read back as "****" or "<redacted>" are never written back. The
-// second return value is false when the value should be omitted entirely (e.g. an
-// object that became empty solely because all of its leaves were redacted).
+// is set, so secrets read back as "****", "<redacted>" or "" are never written back.
+// Note that this means an intentionally empty string inside a complex type is omitted
+// when IgnoreMissingProperty is set, matching UpdateObject's behaviour. The second
+// return value is false when the value should be omitted entirely (e.g. an object that
+// became empty solely because all of its leaves were redacted).
 func fullValueForPatch(v interface{}, option UpdateJsonOption) (interface{}, bool) {
 	switch val := v.(type) {
 	case map[string]interface{}:
@@ -321,7 +333,7 @@ func fullValueForPatch(v interface{}, option UpdateJsonOption) (interface{}, boo
 		}
 		return res, true
 	case string:
-		if option.IgnoreMissingProperty && (regexp.MustCompile(`^\*+$`).MatchString(val) || val == "<redacted>" || val == "") {
+		if isRedactedString(val, option) {
 			return nil, false
 		}
 		return val, true

--- a/internal/utils/json.go
+++ b/internal/utils/json.go
@@ -202,9 +202,18 @@ func isZeroValue(value interface{}) bool {
 // DiffObject computes a minimal patch that transforms old -> new.
 // It returns:
 // - nil if there are no changes
-// - a map[string]interface{} with only changed fields for objects
+// - a map[string]interface{} for objects, containing changed top-level properties
 // - a full new array for arrays when they differ
 // - the new primitive value for scalars when they differ
+//
+// Complex-type semantics: Microsoft Graph treats a nested object (a "complex type",
+// e.g. federatedIdentityCredential.claimsMatchingExpression) as a single atomic value
+// on PATCH - the object sent replaces the stored one, and omitted sub-fields revert to
+// their defaults. Therefore, when any field inside a nested object changes, the ENTIRE
+// object is emitted (from the new/config value), not just the changed sub-field. Sending
+// a partial complex value would cause Graph to drop unchanged siblings such as
+// languageVersion (see issue #137). Minimal-diff semantics are kept only at the top
+// level for scalar and array properties, which follow JSON Merge PATCH (RFC 7396).
 //
 // Special handling: OData metadata fields (keys starting with "@odata.") are always
 // included in the result when they exist in the new object and there are other changes.
@@ -220,13 +229,27 @@ func DiffObject(old interface{}, new interface{}, option UpdateJsonOption) inter
 			res := make(map[string]interface{})
 			// include keys present in new
 			for key, newVal := range newMap {
-				if oldVal, ok := oldValue[key]; ok {
+				oldVal, existed := oldValue[key]
+				switch {
+				case !existed:
+					// key doesn't exist in old -> create. Send the value in full,
+					// dropping redacted placeholder leaves.
+					if v, keep := fullValueForPatch(newVal, option); keep {
+						res[key] = v
+					}
+				case isJSONObject(newVal):
+					// Complex-type property. Graph replaces the whole object on
+					// PATCH, so when it changed we must send it in full (issue #137).
+					if !reflect.DeepEqual(oldVal, newVal) {
+						if v, keep := fullValueForPatch(newVal, option); keep {
+							res[key] = v
+						}
+					}
+				default:
+					// Scalars and arrays keep minimal-diff semantics.
 					if d := DiffObject(oldVal, newVal, option); d != nil {
 						res[key] = d
 					}
-				} else {
-					// key doesn't exist in old -> create
-					res[key] = newVal
 				}
 			}
 
@@ -268,4 +291,41 @@ func DiffObject(old interface{}, new interface{}, option UpdateJsonOption) inter
 	}
 	// primitives or differing types -> return new
 	return new
+}
+
+// isJSONObject reports whether v is a JSON object (map), i.e. a Graph complex type.
+func isJSONObject(v interface{}) bool {
+	_, ok := v.(map[string]interface{})
+	return ok
+}
+
+// fullValueForPatch returns the value to include in a PATCH body when a property must
+// be sent in full (a Graph complex type, or a newly added property). It preserves the
+// entire value but drops redacted/placeholder string leaves when IgnoreMissingProperty
+// is set, so secrets read back as "****" or "<redacted>" are never written back. The
+// second return value is false when the value should be omitted entirely (e.g. an
+// object that became empty solely because all of its leaves were redacted).
+func fullValueForPatch(v interface{}, option UpdateJsonOption) (interface{}, bool) {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		res := make(map[string]interface{})
+		for k, sub := range val {
+			if cleaned, keep := fullValueForPatch(sub, option); keep {
+				res[k] = cleaned
+			}
+		}
+		// Keep an explicitly empty object, but drop one that became empty only
+		// because every leaf was a redacted placeholder.
+		if len(res) == 0 && len(val) != 0 {
+			return nil, false
+		}
+		return res, true
+	case string:
+		if option.IgnoreMissingProperty && (regexp.MustCompile(`^\*+$`).MatchString(val) || val == "<redacted>" || val == "") {
+			return nil, false
+		}
+		return val, true
+	default:
+		return v, true
+	}
 }

--- a/internal/utils/json.go
+++ b/internal/utils/json.go
@@ -71,14 +71,16 @@ type UpdateJsonOption struct {
 	IgnoreNullProperty    bool
 }
 
+var redactedAsterisksRE = regexp.MustCompile(`^\*+$`)
+
 // isRedactedString reports whether s is a placeholder that Graph returned instead of the
-// real value, and therefore must never be written back. An empty string is included
-// because Graph omits or blanks out several write-only properties on read.
+// real value, and therefore should not be written back when IgnoreMissingProperty is enabled.
+// An empty string is included because Graph omits or blanks out several write-only properties on read.
 func isRedactedString(s string, option UpdateJsonOption) bool {
 	if !option.IgnoreMissingProperty {
 		return false
 	}
-	return regexp.MustCompile(`^\*+$`).MatchString(s) || s == "<redacted>" || s == ""
+	return redactedAsterisksRE.MatchString(s) || s == "<redacted>" || s == ""
 }
 
 // UpdateObject is used to get an updated object which has same schema as old, but with new value

--- a/internal/utils/json.go
+++ b/internal/utils/json.go
@@ -212,18 +212,16 @@ func isZeroValue(value interface{}) bool {
 // DiffObject computes a minimal patch that transforms old -> new.
 // It returns:
 // - nil if there are no changes
-// - a map[string]interface{} for objects, containing changed top-level properties
-// - a full new array for arrays when they differ
-// - the new primitive value for scalars when they differ
+// - a map[string]interface{} listing every changed top-level property in full
+// - the new value itself for arrays and scalars when they differ
 //
-// Complex-type semantics: Microsoft Graph treats a nested object (a "complex type",
-// e.g. federatedIdentityCredential.claimsMatchingExpression) as a single atomic value
-// on PATCH - the object sent replaces the stored one, and omitted sub-fields revert to
-// their defaults. Therefore, when any field inside a nested object changes, the ENTIRE
-// object is emitted (from the new/config value), not just the changed sub-field. Sending
-// a partial complex value would cause Graph to drop unchanged siblings such as
-// languageVersion (see issue #137). Minimal-diff semantics are kept only at the top
-// level for scalar and array properties, which follow JSON Merge PATCH (RFC 7396).
+// Values are never partially diffed. Microsoft Graph applies JSON Merge PATCH (RFC 7396)
+// at the top level only: a nested object (a "complex type", e.g.
+// federatedIdentityCredential.claimsMatchingExpression) is replaced wholesale, so any
+// sub-field omitted from the request reverts to its default. Arrays and scalars are
+// replaced the same way. Every changed property is therefore emitted in full from the
+// new/config value - sending a partial complex value would drop unchanged siblings such
+// as languageVersion (see issue #137).
 //
 // Special handling: OData metadata fields (keys starting with "@odata.") are always
 // included in the result when they exist in the new object and there are other changes.
@@ -239,27 +237,13 @@ func DiffObject(old interface{}, new interface{}, option UpdateJsonOption) inter
 			res := make(map[string]interface{})
 			// include keys present in new
 			for key, newVal := range newMap {
-				oldVal, existed := oldValue[key]
-				switch {
-				case !existed:
-					// key doesn't exist in old -> create. Send the value in full,
-					// dropping redacted placeholder leaves.
-					if v, keep := fullValueForPatch(newVal, option); keep {
-						res[key] = v
-					}
-				case isJSONObject(newVal):
-					// Complex-type property. Graph replaces the whole object on
-					// PATCH, so when it changed we must send it in full (issue #137).
-					if DiffObject(oldVal, newVal, option) != nil {
-						if v, keep := fullValueForPatch(newVal, option); keep {
-							res[key] = v
-						}
-					}
-				default:
-					// Scalars and arrays keep minimal-diff semantics.
+				if oldVal, ok := oldValue[key]; ok {
 					if d := DiffObject(oldVal, newVal, option); d != nil {
-						res[key] = d
+						res[key] = newVal
 					}
+				} else {
+					// key doesn't exist in old -> create
+					res[key] = newVal
 				}
 			}
 
@@ -301,43 +285,4 @@ func DiffObject(old interface{}, new interface{}, option UpdateJsonOption) inter
 	}
 	// primitives or differing types -> return new
 	return new
-}
-
-// isJSONObject reports whether v is a JSON object (map), i.e. a Graph complex type.
-func isJSONObject(v interface{}) bool {
-	_, ok := v.(map[string]interface{})
-	return ok
-}
-
-// fullValueForPatch returns the value to include in a PATCH body when a property must
-// be sent in full (a Graph complex type, or a newly added property). It preserves the
-// entire value but drops redacted/placeholder string leaves when IgnoreMissingProperty
-// is set, so secrets read back as "****", "<redacted>" or "" are never written back.
-// Note that this means an intentionally empty string inside a complex type is omitted
-// when IgnoreMissingProperty is set, matching UpdateObject's behaviour. The second
-// return value is false when the value should be omitted entirely (e.g. an object that
-// became empty solely because all of its leaves were redacted).
-func fullValueForPatch(v interface{}, option UpdateJsonOption) (interface{}, bool) {
-	switch val := v.(type) {
-	case map[string]interface{}:
-		res := make(map[string]interface{})
-		for k, sub := range val {
-			if cleaned, keep := fullValueForPatch(sub, option); keep {
-				res[k] = cleaned
-			}
-		}
-		// Keep an explicitly empty object, but drop one that became empty only
-		// because every leaf was a redacted placeholder.
-		if len(res) == 0 && len(val) != 0 {
-			return nil, false
-		}
-		return res, true
-	case string:
-		if isRedactedString(val, option) {
-			return nil, false
-		}
-		return val, true
-	default:
-		return v, true
-	}
 }

--- a/internal/utils/json.go
+++ b/internal/utils/json.go
@@ -215,13 +215,10 @@ func isZeroValue(value interface{}) bool {
 // - a map[string]interface{} listing every changed top-level property in full
 // - the new value itself for arrays and scalars when they differ
 //
-// Values are never partially diffed. Microsoft Graph applies JSON Merge PATCH (RFC 7396)
-// at the top level only: a nested object (a "complex type", e.g.
-// federatedIdentityCredential.claimsMatchingExpression) is replaced wholesale, so any
-// sub-field omitted from the request reverts to its default. Arrays and scalars are
-// replaced the same way. Every changed property is therefore emitted in full from the
-// new/config value - sending a partial complex value would drop unchanged siblings such
-// as languageVersion (see issue #137).
+// Changed values are never partially diffed. RFC 7396 would merge a nested object, but
+// some Graph endpoints replace a complex type wholesale, resetting omitted sub-fields to
+// their defaults (issue #137: patching claimsMatchingExpression.value reset
+// languageVersion).
 //
 // Special handling: OData metadata fields (keys starting with "@odata.") are always
 // included in the result when they exist in the new object and there are other changes.

--- a/internal/utils/json_test.go
+++ b/internal/utils/json_test.go
@@ -309,6 +309,74 @@ func TestDiffObject(t *testing.T) {
 			opt:  UpdateJsonOption{},
 			want: map[string]interface{}{"a": []interface{}{}},
 		},
+		{
+			name: "nested complex type changed -> full object sent",
+			old: map[string]interface{}{
+				"name": "acctest-github-federated-oidc",
+				"claimsMatchingExpression": map[string]interface{}{
+					"value":           "claims['sub'] matches 'repo:contoso/*'",
+					"languageVersion": 1,
+				},
+			},
+			newV: map[string]interface{}{
+				"name": "acctest-github-federated-oidc",
+				"claimsMatchingExpression": map[string]interface{}{
+					"value":           "claims['sub'] matches 'repo:contoso@123456/*'",
+					"languageVersion": 1,
+				},
+			},
+			opt: UpdateJsonOption{},
+			want: map[string]interface{}{
+				"claimsMatchingExpression": map[string]interface{}{
+					"value":           "claims['sub'] matches 'repo:contoso@123456/*'",
+					"languageVersion": 1,
+				},
+			},
+		},
+		{
+			name: "new complex type property with only redacted leaves -> omitted entirely",
+			old:  map[string]interface{}{"name": "test"},
+			newV: map[string]interface{}{
+				"name":        "test",
+				"credentials": map[string]interface{}{"secretText": "****"},
+			},
+			opt:  UpdateJsonOption{IgnoreMissingProperty: true},
+			want: nil,
+		},
+		{
+			name: "new complex type property -> sent in full without redacted leaves",
+			old:  map[string]interface{}{"name": "test"},
+			newV: map[string]interface{}{
+				"name":        "test",
+				"credentials": map[string]interface{}{"displayName": "cred", "secretText": "****"},
+			},
+			opt: UpdateJsonOption{IgnoreMissingProperty: true},
+			want: map[string]interface{}{
+				"credentials": map[string]interface{}{"displayName": "cred"},
+			},
+		},
+		{
+			name: "complex type differing only by redacted leaf -> no change",
+			old: map[string]interface{}{
+				"credentials": map[string]interface{}{"displayName": "cred", "secretText": "s3cret"},
+			},
+			newV: map[string]interface{}{
+				"credentials": map[string]interface{}{"displayName": "cred", "secretText": "****"},
+			},
+			opt:  UpdateJsonOption{IgnoreMissingProperty: true},
+			want: nil,
+		},
+		{
+			name: "complex type differing only by casing -> no change when IgnoreCasing",
+			old: map[string]interface{}{
+				"settings": map[string]interface{}{"value": "Enabled"},
+			},
+			newV: map[string]interface{}{
+				"settings": map[string]interface{}{"value": "enabled"},
+			},
+			opt:  UpdateJsonOption{IgnoreCasing: true},
+			want: nil,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/utils/json_test.go
+++ b/internal/utils/json_test.go
@@ -126,7 +126,7 @@ func TestDiffObject(t *testing.T) {
 			old:  map[string]interface{}{"a": 1, "b": 2, "c": map[string]interface{}{"d": 4}},
 			newV: map[string]interface{}{"a": 1, "b": 3, "c": map[string]interface{}{"d": 4, "e": 5}, "f": 6},
 			opt:  UpdateJsonOption{},
-			want: map[string]interface{}{"b": 3, "c": map[string]interface{}{"e": 5}, "f": 6},
+			want: map[string]interface{}{"b": 3, "c": map[string]interface{}{"d": 4, "e": 5}, "f": 6},
 		},
 		{
 			name: "array changed -> full array returned",

--- a/internal/utils/json_test.go
+++ b/internal/utils/json_test.go
@@ -334,28 +334,6 @@ func TestDiffObject(t *testing.T) {
 			},
 		},
 		{
-			name: "new complex type property with only redacted leaves -> omitted entirely",
-			old:  map[string]interface{}{"name": "test"},
-			newV: map[string]interface{}{
-				"name":        "test",
-				"credentials": map[string]interface{}{"secretText": "****"},
-			},
-			opt:  UpdateJsonOption{IgnoreMissingProperty: true},
-			want: nil,
-		},
-		{
-			name: "new complex type property -> sent in full without redacted leaves",
-			old:  map[string]interface{}{"name": "test"},
-			newV: map[string]interface{}{
-				"name":        "test",
-				"credentials": map[string]interface{}{"displayName": "cred", "secretText": "****"},
-			},
-			opt: UpdateJsonOption{IgnoreMissingProperty: true},
-			want: map[string]interface{}{
-				"credentials": map[string]interface{}{"displayName": "cred"},
-			},
-		},
-		{
 			name: "complex type differing only by redacted leaf -> no change",
 			old: map[string]interface{}{
 				"credentials": map[string]interface{}{"displayName": "cred", "secretText": "s3cret"},


### PR DESCRIPTION
## Problem

`DiffObject` was computing a minimal diff at every level, so changing one sub-field produced a partial object. Updating `claimsMatchingExpression.value` on a federated identity credential sent only `value`, and Graph reset `languageVersion` to its default.

## Fix

`DiffObject` now emits the entire object whenever a nested object changes. Minimal-diff semantics are kept at the top level for scalars and arrays, which do follow JSON Merge PATCH.

Change detection routes through `DiffObject` rather than a raw `reflect.DeepEqual`, so `IgnoreCasing` and `IgnoreMissingProperty` are honoured — an object whose only difference is a recased string or a `"****"` placeholder read back from Graph is not re-sent.

fix issue #137 

## Test
acctest result: https://dev.azure.com/azclitools/internal/_build/results?buildId=334251&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=e722f262-b132-5c61-9453-a20c0496ffb3
