### PR TITLE
fix: fix empty body when import resource with $ref

### DIFF
--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -209,12 +209,28 @@ func (r *MSGraphResource) ModifyPlan(ctx context.Context, request resource.Modif
 	}
 
 	if strings.Contains(plan.Url.ValueString(), "/$ref") {
-		if !dynamic.SemanticallyEqual(plan.Body, state.Body) {
+		// A relationship is identified only by the object it references, so compare
+		// object IDs rather than the `@odata.id` text: Microsoft Graph accepts
+		// several equivalent URL forms, and `id` is populated even when `body` is
+		// absent (imported or older state). Same reference means no replacement
+		// (issue #91). `body` is left at its configured value because it is not
+		// Computed; any remaining difference becomes an in-place update that Update
+		// simply persists.
+		planRefID := relationshipRefObjectID(plan.Body)
+		stateRefID := state.Id.ValueString()
+		if stateRefID == "" {
+			stateRefID = relationshipRefObjectID(state.Body)
+		}
+
+		sameReference := planRefID != "" && strings.EqualFold(planRefID, stateRefID)
+		if !sameReference && !dynamic.SemanticallyEqual(plan.Body, state.Body) {
 			response.RequiresReplace.Append(path.Root("body"))
 		}
+
 		if !reflect.DeepEqual(plan.ResponseExportValues, state.ResponseExportValues) {
 			response.RequiresReplace.Append(path.Root("response_export_values"))
 		}
+
 		if !reflect.DeepEqual(plan.ApiVersion, state.ApiVersion) {
 			response.RequiresReplace.Append(path.Root("api_version"))
 		}
@@ -253,7 +269,7 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 		if requestMap, ok := requestBody.(map[string]interface{}); ok {
 			if idValue, ok := requestMap["@odata.id"]; ok {
 				if idString, ok := idValue.(string); ok {
-					uuidValue := idString[strings.LastIndex(idString, "/")+1:]
+					uuidValue := utils.LastSegment(idString)
 					model.Id = types.StringValue(uuidValue)
 					// For $ref URLs, resource_url should be the collection URL without $ref + the ID
 					baseUrl := strings.TrimSuffix(model.Url.ValueString(), "/$ref")
@@ -307,7 +323,17 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// relationship updates are not supported
+	// A relationship ($ref) has nothing to update: a changed reference forces a
+	// replacement in ModifyPlan, so reaching Update means only local values (such
+	// as a `body` absent from imported state) changed. Persist them without
+	// calling Graph, which does not support PATCH on a relationship URL.
+	if strings.HasSuffix(model.Url.ValueString(), "/$ref") {
+		if model.Output.IsUnknown() {
+			model.Output = types.DynamicNull()
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+		return
+	}
 
 	updateTimeout, diags := model.Timeouts.Update(ctx, 30*time.Minute)
 	resp.Diagnostics.Append(diags...)
@@ -416,13 +442,7 @@ func (r *MSGraphResource) Read(ctx context.Context, req resource.ReadRequest, re
 			resp.Diagnostics.AddError("Failed to read collection", err.Error())
 			return
 		}
-		found := false
-		for _, refId := range referenceIds {
-			if refId == model.Id.ValueString() {
-				found = true
-				break
-			}
-		}
+		found := containsRefID(referenceIds, model.Id.ValueString())
 		if !found {
 			tflog.Info(ctx, fmt.Sprintf("Resource %q not found in collection %q - removing from state", model.Id.ValueString(), collectionUrl))
 			resp.State.RemoveResource(ctx)
@@ -430,15 +450,7 @@ func (r *MSGraphResource) Read(ctx context.Context, req resource.ReadRequest, re
 		}
 
 		if v, _ := req.Private.GetKey(ctx, FlagMoveState); v != nil && string(v) == "true" {
-			body := map[string]string{
-				"@odata.id": fmt.Sprintf("%s/%s/directoryObjects/%s", r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), model.Id.ValueString()),
-			}
-			data, err := json.Marshal(body)
-			if err != nil {
-				resp.Diagnostics.AddError("Invalid body", err.Error())
-				return
-			}
-			payload, err := dynamic.FromJSONImplied(data)
+			payload, err := relationshipRefBody(r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), model.Id.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Invalid payload", err.Error())
 				return
@@ -582,13 +594,7 @@ func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResource
 				}
 				return nil, err
 			}
-			found := false
-			for _, refId := range referenceIds {
-				if refId == model.Id.ValueString() {
-					found = true
-					break
-				}
-			}
+			found := containsRefID(referenceIds, model.Id.ValueString())
 			return &found, nil
 		}
 
@@ -681,7 +687,103 @@ func (r *MSGraphResource) ImportState(ctx context.Context, req resource.ImportSt
 			}),
 		},
 	}
+
+	// For a relationship ($ref) resource, confirm the reference actually exists
+	// and reconstruct its `body`, mirroring how azapi's ImportState issues a GET
+	// and populates `body` from the response.
+	//
+	// Microsoft Graph has no single-reference GET (only DELETE targets
+	// `.../{id}/$ref`), so existence is verified by listing the collection. The
+	// list yields clean object IDs, so the canonical `.../directoryObjects/{id}`
+	// form is rebuilt from `id` rather than parsing the returned `@odata.id`,
+	// whose `$ref` form can carry a tenant prefix and a type-cast suffix.
+	// ModifyPlan compares only the referenced object ID, so a configuration that
+	// uses an equivalent form (for example `.../users/{id}`) still plans cleanly.
+	if strings.HasSuffix(urlValue, "/$ref") {
+		if r.client == nil {
+			resp.Diagnostics.AddError("Provider not configured", "The Microsoft Graph client is not configured; cannot import a relationship resource.")
+			return
+		}
+
+		collectionUrl := baseCollectionUrl(urlValue)
+		options := clients.RequestOptions{
+			QueryParameters: clients.NewQueryParameters(nil),
+			RetryOptions:    clients.NewRetryOptions(retry.NewValueNull()),
+		}
+		referenceIds, err := r.client.ListRefIDs(ctx, collectionUrl, apiVersion, options)
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to read collection", fmt.Sprintf("listing references for %q: %s", collectionUrl, err.Error()))
+			return
+		}
+
+		if !containsRefID(referenceIds, id) {
+			resp.Diagnostics.AddError(
+				"Reference not found",
+				fmt.Sprintf("The object %q is not a member of the collection %q, so there is nothing to import.", id, collectionUrl),
+			)
+			return
+		}
+
+		payload, err := relationshipRefBody(r.client.GraphBaseUrl(), apiVersion, id)
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid payload", err.Error())
+			return
+		}
+		model.Body = payload
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+// relationshipRefBody builds the canonical relationship ($ref) body for the
+// given object ID: { "@odata.id": "<graphBaseURL>/<apiVersion>/directoryObjects/<id>" }.
+// `directoryObjects` is the base type that is valid for every directory object
+// (user, group, device, service principal, ...), so it is used regardless of
+// the referenced object's concrete type. ModifyPlan compares only the trailing
+// object ID, so this canonical form still matches an equivalent configuration
+// such as ".../users/{id}".
+func relationshipRefBody(graphBaseURL, apiVersion, id string) (types.Dynamic, error) {
+	data, err := json.Marshal(map[string]string{
+		"@odata.id": fmt.Sprintf("%s/%s/directoryObjects/%s", graphBaseURL, apiVersion, id),
+	})
+	if err != nil {
+		return types.DynamicNull(), err
+	}
+	return dynamic.FromJSONImplied(data)
+}
+
+// containsRefID reports whether id is present in referenceIds, comparing
+// case-insensitively to tolerate GUID casing differences returned by Microsoft
+// Graph, consistent with reconcileReferenceIdOrder.
+func containsRefID(referenceIds []string, id string) bool {
+	for _, refID := range referenceIds {
+		if strings.EqualFold(refID, id) {
+			return true
+		}
+	}
+	return false
+}
+
+// relationshipRefObjectID extracts the referenced object ID from a relationship
+// ($ref) body. A relationship body has the shape { "@odata.id": "<url>/<id>" }
+// and the trailing path segment is the object ID. Equivalent forms such as
+// ".../directoryObjects/{id}" and ".../users/{id}" therefore yield the same ID.
+// The segment is taken exactly as Create does when deriving `id`, so both agree
+// on what a given `@odata.id` refers to.
+// Returns "" when the body is null/unknown or has no usable @odata.id.
+func relationshipRefObjectID(body types.Dynamic) string {
+	if body.IsNull() || body.IsUnknown() || body.IsUnderlyingValueNull() || body.IsUnderlyingValueUnknown() {
+		return ""
+	}
+	requestBody := make(map[string]interface{})
+	if err := unmarshalBody(body, &requestBody); err != nil {
+		return ""
+	}
+	odataID, ok := requestBody["@odata.id"].(string)
+	if !ok || odataID == "" {
+		return ""
+	}
+	return utils.LastSegment(odataID)
 }
 
 func buildOutputFromBody(body interface{}, paths map[string]string) attr.Value {

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -222,8 +222,12 @@ func (r *MSGraphResource) ModifyPlan(ctx context.Context, request resource.Modif
 			stateRefID = relationshipRefObjectID(state.Body)
 		}
 
+		// An unknown `body` (references a not-yet-created object) can't be proven
+		// to change the reference, so don't force replacement and cascade the
+		// computed `id`/`resource_url` to unknown; Update reconciles it later.
+		bodyUnknown := plan.Body.IsUnknown() || plan.Body.IsUnderlyingValueUnknown()
 		sameReference := planRefID != "" && strings.EqualFold(planRefID, stateRefID)
-		if !sameReference && !dynamic.SemanticallyEqual(plan.Body, state.Body) {
+		if !bodyUnknown && !sameReference && !dynamic.SemanticallyEqual(plan.Body, state.Body) {
 			response.RequiresReplace.Append(path.Root("body"))
 		}
 
@@ -323,10 +327,7 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// A relationship ($ref) has nothing to update: a changed reference forces a
-	// replacement in ModifyPlan, so reaching Update means only local values (such
-	// as a `body` absent from imported state) changed. Persist them without
-	// calling Graph, which does not support PATCH on a relationship URL.
+	// relationship updates are not supported
 	if strings.HasSuffix(model.Url.ValueString(), "/$ref") {
 		if model.Output.IsUnknown() {
 			model.Output = types.DynamicNull()
@@ -686,50 +687,6 @@ func (r *MSGraphResource) ImportState(ctx context.Context, req resource.ImportSt
 				"delete": types.StringType,
 			}),
 		},
-	}
-
-	// For a relationship ($ref) resource, confirm the reference actually exists
-	// and reconstruct its `body`, mirroring how azapi's ImportState issues a GET
-	// and populates `body` from the response.
-	//
-	// Microsoft Graph has no single-reference GET (only DELETE targets
-	// `.../{id}/$ref`), so existence is verified by listing the collection. The
-	// list yields clean object IDs, so the canonical `.../directoryObjects/{id}`
-	// form is rebuilt from `id` rather than parsing the returned `@odata.id`,
-	// whose `$ref` form can carry a tenant prefix and a type-cast suffix.
-	// ModifyPlan compares only the referenced object ID, so a configuration that
-	// uses an equivalent form (for example `.../users/{id}`) still plans cleanly.
-	if strings.HasSuffix(urlValue, "/$ref") {
-		if r.client == nil {
-			resp.Diagnostics.AddError("Provider not configured", "The Microsoft Graph client is not configured; cannot import a relationship resource.")
-			return
-		}
-
-		collectionUrl := baseCollectionUrl(urlValue)
-		options := clients.RequestOptions{
-			QueryParameters: clients.NewQueryParameters(nil),
-			RetryOptions:    clients.NewRetryOptions(retry.NewValueNull()),
-		}
-		referenceIds, err := r.client.ListRefIDs(ctx, collectionUrl, apiVersion, options)
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to read collection", fmt.Sprintf("listing references for %q: %s", collectionUrl, err.Error()))
-			return
-		}
-
-		if !containsRefID(referenceIds, id) {
-			resp.Diagnostics.AddError(
-				"Reference not found",
-				fmt.Sprintf("The object %q is not a member of the collection %q, so there is nothing to import.", id, collectionUrl),
-			)
-			return
-		}
-
-		payload, err := relationshipRefBody(r.client.GraphBaseUrl(), apiVersion, id)
-		if err != nil {
-			resp.Diagnostics.AddError("Invalid payload", err.Error())
-			return
-		}
-		model.Body = payload
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -451,7 +451,15 @@ func (r *MSGraphResource) Read(ctx context.Context, req resource.ReadRequest, re
 		}
 
 		if v, _ := req.Private.GetKey(ctx, FlagMoveState); v != nil && string(v) == "true" {
-			payload, err := relationshipRefBody(r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), model.Id.ValueString())
+			body := map[string]string{
+				"@odata.id": fmt.Sprintf("%s/%s/directoryObjects/%s", r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), model.Id.ValueString()),
+			}
+			data, err := json.Marshal(body)
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid body", err.Error())
+				return
+			}
+			payload, err := dynamic.FromJSONImplied(data)
 			if err != nil {
 				resp.Diagnostics.AddError("Invalid payload", err.Error())
 				return
@@ -690,23 +698,6 @@ func (r *MSGraphResource) ImportState(ctx context.Context, req resource.ImportSt
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
-}
-
-// relationshipRefBody builds the canonical relationship ($ref) body for the
-// given object ID: { "@odata.id": "<graphBaseURL>/<apiVersion>/directoryObjects/<id>" }.
-// `directoryObjects` is the base type that is valid for every directory object
-// (user, group, device, service principal, ...), so it is used regardless of
-// the referenced object's concrete type. ModifyPlan compares only the trailing
-// object ID, so this canonical form still matches an equivalent configuration
-// such as ".../users/{id}".
-func relationshipRefBody(graphBaseURL, apiVersion, id string) (types.Dynamic, error) {
-	data, err := json.Marshal(map[string]string{
-		"@odata.id": fmt.Sprintf("%s/%s/directoryObjects/%s", graphBaseURL, apiVersion, id),
-	})
-	if err != nil {
-		return types.DynamicNull(), err
-	}
-	return dynamic.FromJSONImplied(data)
 }
 
 // containsRefID reports whether id is present in referenceIds, comparing

--- a/internal/services/msgraph_resource_internal_test.go
+++ b/internal/services/msgraph_resource_internal_test.go
@@ -4,6 +4,9 @@ import (
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/microsoft/terraform-provider-msgraph/internal/dynamic"
 )
 
 func TestResolveResourceID(t *testing.T) {
@@ -124,6 +127,51 @@ func TestReconcileReferenceIdOrder(t *testing.T) {
 			got := reconcileReferenceIdOrder(tt.previous, tt.current)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("expected %#v, got %#v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestRelationshipRefObjectID(t *testing.T) {
+	mustDynamic := func(jsonBody string) types.Dynamic {
+		v, err := dynamic.FromJSONImplied([]byte(jsonBody))
+		if err != nil {
+			t.Fatalf("failed to build dynamic value from %q: %s", jsonBody, err)
+		}
+		return v
+	}
+
+	tests := []struct {
+		name string
+		body types.Dynamic
+		want string
+	}{
+		{
+			name: "directoryObjects form",
+			body: mustDynamic(`{"@odata.id":"https://graph.microsoft.com/v1.0/directoryObjects/00000000-0000-0000-0000-000000000001"}`),
+			want: "00000000-0000-0000-0000-000000000001",
+		},
+		{
+			name: "users form resolves to same id",
+			body: mustDynamic(`{"@odata.id":"https://graph.microsoft.com/v1.0/users/00000000-0000-0000-0000-000000000001"}`),
+			want: "00000000-0000-0000-0000-000000000001",
+		},
+		{
+			name: "null body yields empty",
+			body: types.DynamicNull(),
+			want: "",
+		},
+		{
+			name: "body without @odata.id yields empty",
+			body: mustDynamic(`{"displayName":"not a ref"}`),
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := relationshipRefObjectID(tt.body); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
 			}
 		})
 	}

--- a/internal/services/msgraph_resource_test.go
+++ b/internal/services/msgraph_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/microsoft/terraform-provider-msgraph/internal/acceptance"
 	"github.com/microsoft/terraform-provider-msgraph/internal/acceptance/check"
@@ -87,6 +88,34 @@ func TestAcc_ResourceGroupMember(t *testing.T) {
 			),
 		},
 		importStep,
+	})
+}
+
+func TestAcc_ResourceGroupMemberImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "msgraph_resource", "test")
+
+	r := MSGraphTestResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.groupMember(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Exists(r),
+			),
+		},
+		{
+			Config:             r.groupMember(),
+			ResourceName:       data.ResourceName,
+			ImportState:        true,
+			ImportStateKind:    resource.ImportBlockWithID,
+			ImportStateIdFunc:  r.ImportIdFuncWithBetaApiVersion,
+			ExpectNonEmptyPlan: true,
+			ImportPlanChecks: resource.ImportPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionUpdate),
+				},
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
Fixes `$ref` relationship handling in MSGraphResource. References are compared by object ID (from `@odata.id`) instead of URL string, import no longer reconstructs body, and an unknown reference no longer forces a replacement — all of which prevent spurious destroy/recreate. Adds supporting utilities and tests. 

**Relationship reference handling:**

- `$ref` references are compared using object IDs extracted from @odata.id, not the full URL string, so equivalent-but-differently-formatted URLs no longer force a replacement.
- Added `LastSegment` to extract the trailing object ID from an `@odata.id`, used by `Create` and by the new `relationshipRefObjectID` helper (used in `ModifyPlan`).
- ModifyPlan treats an unknown `plan.Body` as "no replacement", so a reference to a not-yet-created object doesn't cascade into a destroy/recreate.
- Update logic handles unknown outputs for relationship resources and skips unsupported $ref updates.

**Reference ID comparison and utilities:**

- Added `containsRefID` for case-insensitive reference ID comparison during existence checks and state reconciliation.
- Added unit tests for `relationshipRefObjectID` covering several reference body formats.

**Testing:**

- Added an acceptance test for importing a group member, with plan checks asserting the post-import action is an update, not a replacement.

Fixes #91.