### PR TITLE
feat: Support `create_method` in msgraph_resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 - Added sovereign cloud support via optional `environment` (`ARM_ENVIRONMENT`) for `public/global`, `usgovernment/usgovernmentl4`, `usgovernmentl5/dod`, and `china`, including cloud-based Graph endpoint/token-scope resolution and `@odata.id` relationship URLs.
+- `msgraph_resource`: Added a `create_method` attribute (`POST` default, or `PUT`) to support Graph resources that are created via `PUT` on the resource URL.
 
 BUG FIXES:
 - `msgraph_resource_collection`: Fixed a "Provider produced inconsistent final plan" error on `reference_ids` that occurred when only some referenced resources were updated in the same apply (a mix of known and known-after-apply values). Because a `/$ref` collection is unordered, reads now preserve the ordering already recorded in state, keeping the stored order aligned with the configured order so pinned positions no longer shift between plan and apply. ([#135](https://github.com/microsoft/terraform-provider-msgraph/issues/135))

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -71,6 +71,7 @@ This resource can manage any Microsoft Graph API resource.
 
 - `api_version` (String) The API version of the data source. The allowed values are `v1.0` and `beta`. Defaults to `v1.0`.
 - `body` (Dynamic) A dynamic attribute that contains the request body.
+- `create_method` (String) The HTTP method to use for creating the resource. Allowed values are `POST` (default) and `PUT`.
 - `create_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the create request.
 - `delete_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the delete request.
 - `ignore_missing_property` (Boolean) Whether ignore not returned properties like credentials in `body` to suppress plan-diff. Defaults to `true`. It's recommend to enable this option when some sensitive properties are not returned in response body, instead of setting them in `lifecycle.ignore_changes` because it will make the sensitive fields unable to update.

--- a/internal/clients/msgraph_client.go
+++ b/internal/clients/msgraph_client.go
@@ -220,11 +220,14 @@ func (client *MSGraphClient) List(ctx context.Context, url string, apiVersion st
 	return out, nil
 }
 
-func (client *MSGraphClient) Create(ctx context.Context, url string, apiVersion string, body interface{}, options RequestOptions) (interface{}, string, error) {
+func (client *MSGraphClient) Create(ctx context.Context, method string, url string, apiVersion string, body interface{}, options RequestOptions) (interface{}, string, error) {
 	if options.RetryOptions != nil {
 		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
 	}
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, apiVersion, url))
+	if method == "" {
+		method = http.MethodPost
+	}
+	req, err := runtime.NewRequest(ctx, method, runtime.JoinPaths(client.host, apiVersion, url))
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -72,6 +72,7 @@ type MSGraphResourceModel struct {
 	Output                types.Dynamic     `tfsdk:"output"`
 	Timeouts              timeouts.Value    `tfsdk:"timeouts"`
 	UpdateMethod          types.String      `tfsdk:"update_method"`
+	CreateMethod          types.String      `tfsdk:"create_method"`
 }
 
 func (r *MSGraphResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -172,6 +173,14 @@ func (r *MSGraphResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 
+			"create_method": schema.StringAttribute{
+				MarkdownDescription: "The HTTP method to use for creating the resource. Allowed values are `POST` (default) and `PUT`.",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("POST", "PUT"),
+				},
+			},
+
 			"resource_url": schema.StringAttribute{
 				MarkdownDescription: "The full URL path to this resource instance.",
 				Computed:            true,
@@ -243,7 +252,22 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 		QueryParameters: clients.NewQueryParameters(AsMapOfLists(model.CreateQueryParameters)),
 		RetryOptions:    clients.NewRetryOptions(model.Retry),
 	}
-	responseBody, location, err := r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), requestBody, options)
+
+	createMethod := "POST"
+	if !model.CreateMethod.IsNull() {
+		createMethod = model.CreateMethod.ValueString()
+	}
+
+	var (
+		responseBody interface{}
+		location     string
+		err          error
+	)
+	if createMethod == "PUT" {
+		responseBody, err = r.client.Action(ctx, "PUT", model.Url.ValueString(), model.ApiVersion.ValueString(), requestBody, options)
+	} else {
+		responseBody, location, err = r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), requestBody, options)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create resource", err.Error())
 		return
@@ -261,6 +285,22 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 				}
 			}
 		}
+	} else if createMethod == "PUT" {
+		// PUT targets the resource URL directly (upsert), so the URL itself
+		// identifies the resource and the response may omit a top-level `id`.
+		putID := ""
+		if responseMap, ok := responseBody.(map[string]interface{}); ok {
+			if id, ok := responseMap["id"].(string); ok {
+				putID = id
+			}
+		}
+		if putID == "" {
+			trimmed := strings.TrimRight(model.Url.ValueString(), "/")
+			putID = trimmed[strings.LastIndex(trimmed, "/")+1:]
+		}
+
+		model.Id = types.StringValue(putID)
+		model.ResourceUrl = model.Url
 	} else {
 		responseId, err := resolveResourceID(responseBody, location)
 		if err != nil {
@@ -286,10 +326,20 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 				clients.NewRetryOptions(model.Retry),
 			),
 		}
-		responseBody, err = r.client.Read(ctx, fmt.Sprintf("%s/%s", model.Url.ValueString(), model.Id.ValueString()), model.ApiVersion.ValueString(), options)
+		responseBody, err = r.client.Read(ctx, resourceItemUrl(model), model.ApiVersion.ValueString(), options)
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to read data source", err.Error())
 			return
+		}
+
+		// PUT upsert responses may omit a top-level `id` (e.g. 204 No Content), so
+		// prefer the authoritative `id` returned by the read after create.
+		if createMethod == "PUT" {
+			if responseMap, ok := responseBody.(map[string]interface{}); ok {
+				if id, ok := responseMap["id"].(string); ok && id != "" {
+					model.Id = types.StringValue(id)
+				}
+			}
 		}
 	}
 
@@ -331,7 +381,7 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 		updateMethod = model.UpdateMethod.ValueString()
 	}
 	if updateMethod == "PUT" {
-		_, err := r.client.Action(ctx, "PUT", fmt.Sprintf("%s/%s", model.Url.ValueString(), model.Id.ValueString()), model.ApiVersion.ValueString(), requestBody, options)
+		_, err := r.client.Action(ctx, "PUT", resourceItemUrl(model), model.ApiVersion.ValueString(), requestBody, options)
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to update resource", err.Error())
 			return
@@ -352,7 +402,7 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 
 		// If there's something to update, send PATCH
 		if patchBody != nil {
-			_, err := r.client.Update(ctx, fmt.Sprintf("%s/%s", model.Url.ValueString(), model.Id.ValueString()), model.ApiVersion.ValueString(), patchBody, options)
+			_, err := r.client.Update(ctx, resourceItemUrl(model), model.ApiVersion.ValueString(), patchBody, options)
 			if err != nil {
 				resp.Diagnostics.AddError("Failed to create resource", err.Error())
 				return
@@ -372,7 +422,7 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 		QueryParameters: clients.NewQueryParameters(AsMapOfLists(model.ReadQueryParameters)),
 		RetryOptions:    clients.NewRetryOptions(model.Retry),
 	}
-	responseBody, err := r.client.Read(ctx, fmt.Sprintf("%s/%s", model.Url.ValueString(), model.Id.ValueString()), model.ApiVersion.ValueString(), options)
+	responseBody, err := r.client.Read(ctx, resourceItemUrl(model), model.ApiVersion.ValueString(), options)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read data source", err.Error())
 		return
@@ -453,7 +503,7 @@ func (r *MSGraphResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	options := clients.NewRequestOptions(nil, AsMapOfLists(model.ReadQueryParameters))
-	responseBody, err := r.client.Read(ctx, fmt.Sprintf("%s/%s", model.Url.ValueString(), model.Id.ValueString()), model.ApiVersion.ValueString(), options)
+	responseBody, err := r.client.Read(ctx, resourceItemUrl(model), model.ApiVersion.ValueString(), options)
 	if err != nil {
 		if utils.ResponseErrorWasNotFound(err) {
 			tflog.Info(ctx, fmt.Sprintf("Error reading %q - removing from state", model.Id.ValueString()))
@@ -526,7 +576,7 @@ func (r *MSGraphResource) Delete(ctx context.Context, req resource.DeleteRequest
 	if strings.HasSuffix(model.Url.ValueString(), "/$ref") {
 		itemUrl = strings.ReplaceAll(model.Url.ValueString(), "/$ref", fmt.Sprintf("/%s/$ref", model.Id.ValueString()))
 	} else {
-		itemUrl = fmt.Sprintf("%s/%s", model.Url.ValueString(), model.Id.ValueString())
+		itemUrl = resourceItemUrl(model)
 	}
 
 	options := clients.RequestOptions{
@@ -596,7 +646,7 @@ func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResource
 			QueryParameters: clients.NewQueryParameters(AsMapOfLists(model.ReadQueryParameters)),
 			RetryOptions:    retryOptions,
 		}
-		itemUrl := fmt.Sprintf("%s/%s", model.Url.ValueString(), model.Id.ValueString())
+		itemUrl := resourceItemUrl(model)
 		_, err := client.Read(ctx, itemUrl, model.ApiVersion.ValueString(), options)
 		if err != nil {
 			if utils.ResponseErrorWasNotFound(err) {
@@ -724,6 +774,16 @@ func resolveResourceID(responseBody interface{}, location string) (string, error
 	}
 
 	return "", errors.New("unable to determine the resource ID: the create response contained no top-level `id` field and no usable `Location` header")
+}
+
+// resourceItemUrl returns the URL that identifies the resource instance. It uses
+// the computed `resource_url` when available, falling back to `url/id` for state
+// created before `resource_url` was introduced.
+func resourceItemUrl(model *MSGraphResourceModel) string {
+	if resourceUrl := model.ResourceUrl.ValueString(); resourceUrl != "" {
+		return resourceUrl
+	}
+	return fmt.Sprintf("%s/%s", model.Url.ValueString(), model.Id.ValueString())
 }
 
 func (r *MSGraphResource) MoveState(ctx context.Context) []resource.StateMover {

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -273,7 +273,8 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	if isRelationship { // extract the id from the response body
+	switch {
+	case isRelationship: // extract the id from the response body
 		if requestMap, ok := requestBody.(map[string]interface{}); ok {
 			if idValue, ok := requestMap["@odata.id"]; ok {
 				if idString, ok := idValue.(string); ok {
@@ -285,7 +286,7 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 				}
 			}
 		}
-	} else if createMethod == "PUT" {
+	case createMethod == "PUT":
 		// PUT targets the resource URL directly (upsert), so the URL itself
 		// identifies the resource and the response may omit a top-level `id`.
 		putID := ""
@@ -301,7 +302,7 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 
 		model.Id = types.StringValue(putID)
 		model.ResourceUrl = model.Url
-	} else {
+	default:
 		responseId, err := resolveResourceID(responseBody, location)
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to determine resource ID", err.Error())

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -329,7 +329,7 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 		responseBody, err = r.client.Read(ctx, resourceItemUrl(model), model.ApiVersion.ValueString(), options)
 		if err != nil {
-			resp.Diagnostics.AddError("Failed to read data source", err.Error())
+			resp.Diagnostics.AddError("Failed to read resource", err.Error())
 			return
 		}
 
@@ -405,7 +405,7 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 		if patchBody != nil {
 			_, err := r.client.Update(ctx, resourceItemUrl(model), model.ApiVersion.ValueString(), patchBody, options)
 			if err != nil {
-				resp.Diagnostics.AddError("Failed to create resource", err.Error())
+				resp.Diagnostics.AddError("Failed to update resource", err.Error())
 				return
 			}
 		} else {
@@ -425,7 +425,7 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 	responseBody, err := r.client.Read(ctx, resourceItemUrl(model), model.ApiVersion.ValueString(), options)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to read data source", err.Error())
+		resp.Diagnostics.AddError("Failed to read resource", err.Error())
 		return
 	}
 	model.Output = types.DynamicValue(buildOutputFromBody(responseBody, model.ResponseExportValues))

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -258,16 +258,7 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 		createMethod = model.CreateMethod.ValueString()
 	}
 
-	var (
-		responseBody interface{}
-		location     string
-		err          error
-	)
-	if createMethod == "PUT" {
-		responseBody, err = r.client.Action(ctx, "PUT", model.Url.ValueString(), model.ApiVersion.ValueString(), requestBody, options)
-	} else {
-		responseBody, location, err = r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), requestBody, options)
-	}
+	responseBody, location, err := r.client.Create(ctx, createMethod, model.Url.ValueString(), model.ApiVersion.ValueString(), requestBody, options)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create resource", err.Error())
 		return

--- a/internal/services/msgraph_resource_collection.go
+++ b/internal/services/msgraph_resource_collection.go
@@ -319,7 +319,7 @@ func (r *MSGraphResourceCollection) applyCollection(ctx context.Context, model *
 	for _, item := range toAdd {
 		body := map[string]string{}
 		body["@odata.id"] = fmt.Sprintf("%s/%s/directoryObjects/%s", r.client.GraphBaseUrl(), model.ApiVersion.ValueString(), item)
-		_, _, err := r.client.Create(ctx, model.Url.ValueString(), model.ApiVersion.ValueString(), body, clients.RequestOptions{RetryOptions: clients.NewRetryOptions(model.Retry)})
+		_, _, err := r.client.Create(ctx, "", model.Url.ValueString(), model.ApiVersion.ValueString(), body, clients.RequestOptions{RetryOptions: clients.NewRetryOptions(model.Retry)})
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/internal/services/msgraph_resource_test.go
+++ b/internal/services/msgraph_resource_test.go
@@ -264,9 +264,9 @@ func TestAcc_ResourceWithPutUpdateMethod(t *testing.T) {
 }
 
 func TestAcc_ResourceWithPutCreateMethod(t *testing.T) {
-	partnerTenantID := os.Getenv("ARM_PARTNER_TENANT_ID")
+	partnerTenantID := os.Getenv("ARM_CROSS_TENANT_ACCESS_POLICY_PARTNER_TENANT_ID")
 	if partnerTenantID == "" {
-		t.Skip("Skipping as `ARM_PARTNER_TENANT_ID` is not specified")
+		t.Skip("Skipping as `ARM_CROSS_TENANT_ACCESS_POLICY_PARTNER_TENANT_ID` is not specified")
 	}
 
 	data := acceptance.BuildTestData(t, "msgraph_resource", "test")

--- a/internal/services/msgraph_resource_test.go
+++ b/internal/services/msgraph_resource_test.go
@@ -3,6 +3,7 @@ package services_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -262,6 +263,27 @@ func TestAcc_ResourceWithPutUpdateMethod(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceWithPutCreateMethod(t *testing.T) {
+	partnerTenantID := os.Getenv("ARM_PARTNER_TENANT_ID")
+	if partnerTenantID == "" {
+		t.Skip("Skipping as `ARM_PARTNER_TENANT_ID` is not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "msgraph_resource", "test")
+
+	r := MSGraphTestResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.createMethod(partnerTenantID),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Exists(r),
+				check.That(data.ResourceName).Key("resource_url").MatchesRegex(regexp.MustCompile(`^policies/crossTenantAccessPolicy/partners/[a-f0-9\-]+/identitySynchronization$`)),
+			),
+		},
+	})
+}
+
 func TestAcc_ResourceFederatedIdentityCredentialClaimsExpression(t *testing.T) {
 	data := acceptance.BuildTestData(t, "msgraph_resource", "test")
 
@@ -356,7 +378,10 @@ func (r MSGraphTestResource) Exists(ctx context.Context, client *clients.Client,
 		return &found, nil
 	}
 
-	checkUrl := fmt.Sprintf("%s/%s", url, state.ID)
+	checkUrl := state.Attributes["resource_url"]
+	if checkUrl == "" {
+		checkUrl = fmt.Sprintf("%s/%s", url, state.ID)
+	}
 	_, err := client.MSGraphClient.Read(ctx, checkUrl, apiVersion, clients.DefaultRequestOptions())
 	if err == nil {
 		b := true
@@ -668,6 +693,26 @@ resource "msgraph_resource" "test" {
   }
 }
 `, displayName)
+}
+
+func (r MSGraphTestResource) createMethod(partnerTenantID string) string {
+	return fmt.Sprintf(`
+resource "msgraph_resource" "partner" {
+  url = "policies/crossTenantAccessPolicy/partners"
+  body = {
+    tenantId = %[1]q
+  }
+}
+
+resource "msgraph_resource" "test" {
+  url           = "policies/crossTenantAccessPolicy/partners/${msgraph_resource.partner.id}/identitySynchronization"
+  create_method = "PUT"
+  body = {
+    displayName     = "My Sync"
+    userSyncInbound = { isSyncAllowed = true }
+  }
+}
+`, partnerTenantID)
 }
 
 func (r MSGraphTestResource) federatedIdentityCredentialClaimsExpression(value string) string {


### PR DESCRIPTION
## Summary

Adds an optional `create_method` argument to `msgraph_resource` so resources can be created with `PUT` instead of the default `POST`.

Some Graph resources are singletons under a fixed path (e.g. `servicePrincipals/{id}/claimsPolicy`, `policies/crossTenantAccessPolicy/partners/{tenantId}/identitySynchronization`). They have no collection to `POST` into and are create-or-replace via `PUT` on the resource URL. This mirrors the existing `update_method` argument.

Examples:

- https://learn.microsoft.com/en-us/graph/api/crosstenantaccesspolicyconfigurationpartner-put-identitysynchronization?view=graph-rest-1.0&tabs=http
- https://learn.microsoft.com/en-us/graph/api/synchronization-serviceprincipal-put-synchronization?view=graph-rest-1.0&tabs=http

Fixes #108 

## Changes

- Add `create_method` argument (`POST` default, or `PUT`)
- For `PUT` creates, send the request to the resource URL directly. `PUT` may return `204` or no top-level `id`, so the `id` is taken from the read-after-create GET response when available, falling back to the last URL path segment. `resource_url` is set to the PUT target so read/update/delete address the singleton correctly.


## Testing
Existing testing:
https://dev.azure.com/azclitools/internal/_build/results?buildId=342800&view=logs&s=96ac2280-8cb4-5df5-99de-dd2da759617d&j=ca395085-040a-526b-2ce8-bdc85f692774

Local testing:
it requires Global Admin permission and partner tenant id
<img width="2089" height="411" alt="image" src="https://github.com/user-attachments/assets/61b0b18e-91c7-4862-b314-c4572a47e82c" />

