### PR TITLE
fix: Fix destroy failure by tolerating 403 in the deletion poller

### DIFF
--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
@@ -656,7 +657,7 @@ func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResource
 		itemUrl := resourceItemUrl(model)
 		_, err := client.Read(ctx, itemUrl, model.ApiVersion.ValueString(), options)
 		if err != nil {
-			if utils.ResponseErrorWasNotFound(err) || (readAfterDelete && utils.ResponseErrorWasStatusCode(err, 403)) {
+			if utils.ResponseErrorWasNotFound(err) || (readAfterDelete && utils.ResponseErrorWasStatusCode(err, http.StatusForbidden)) {
 				b := false
 				return &b, nil
 			}

--- a/internal/services/msgraph_resource.go
+++ b/internal/services/msgraph_resource.go
@@ -325,7 +325,7 @@ func (r *MSGraphResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Wait for the resource to be available
-	if err = consistency.WaitForUpdate(ctx, ResourceExistenceFunc(r.client, model, true)); err != nil {
+	if err = consistency.WaitForUpdate(ctx, ResourceExistenceFunc(r.client, model, true, false)); err != nil {
 		resp.Diagnostics.AddError("Error", fmt.Sprintf("waiting for creation of %s: %v", model.Url.ValueString(), err))
 		return
 	}
@@ -432,7 +432,7 @@ func (r *MSGraphResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	// Wait for the resource to be available
-	if err := consistency.WaitForUpdate(ctx, ResourceExistenceFunc(r.client, model, false)); err != nil {
+	if err := consistency.WaitForUpdate(ctx, ResourceExistenceFunc(r.client, model, false, false)); err != nil {
 		resp.Diagnostics.AddError("Error", fmt.Sprintf("waiting for update of %s: %v", model.Url.ValueString(), err))
 		return
 	}
@@ -603,12 +603,12 @@ func (r *MSGraphResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	// Wait for deletion to complete
-	if err = consistency.WaitForDeletion(ctx, ResourceExistenceFunc(r.client, model, false)); err != nil {
+	if err = consistency.WaitForDeletion(ctx, ResourceExistenceFunc(r.client, model, false, true)); err != nil {
 		resp.Diagnostics.AddError("Error waiting for deletion", err.Error())
 	}
 }
 
-func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResourceModel, readAfterCreate bool) consistency.ChangeFunc {
+func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResourceModel, readAfterCreate, readAfterDelete bool) consistency.ChangeFunc {
 	return func(ctx context.Context) (*bool, error) {
 		if model == nil {
 			return nil, fmt.Errorf("model is nil")
@@ -656,7 +656,7 @@ func ResourceExistenceFunc(client *clients.MSGraphClient, model *MSGraphResource
 		itemUrl := resourceItemUrl(model)
 		_, err := client.Read(ctx, itemUrl, model.ApiVersion.ValueString(), options)
 		if err != nil {
-			if utils.ResponseErrorWasNotFound(err) {
+			if utils.ResponseErrorWasNotFound(err) || (readAfterDelete && utils.ResponseErrorWasStatusCode(err, 403)) {
 				b := false
 				return &b, nil
 			}


### PR DESCRIPTION
## Problem

Destroying an Access Package Assignment Policy (`identityGovernance/entitlementManagement/assignmentPolicies`) fails with a 403 on the confirmation GET after a successful DELETE, leaving the resource in state.

## Cause

After DELETE, the poller only treats 404 as gone. Entitlement Management authorization is resource-scoped (e.g. Catalog owner SP), so once the policy is deleted Graph can't resolve policy-to-catalog ownership and returns 403 instead of 404.

## Change

- During the deletion wait, a 403 on the item GET is treated the same as 404.

